### PR TITLE
Refine missing red

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ logging
 # trained_models directory
 trained_models
 
+# keys
+.keys/
 
 # logging
 logging

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ projects/test_project/train
 scripts/crop_images.py
 logging
 
+# Ignore exploratory notebooks
+notebooks/
+
 # trained_models directory
 trained_models
 

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -21,18 +21,18 @@ project:
 mode: preprocess                  # one of: mask_gen / preprocess / train / inference
 
 tasks: # TODO: make the other tasks bool key/values
-  preprocess:
-    pad_gridcrop_resize: false
-    train_val_test_split: false
-    compute_data_stats:   false
-  
   mask_gen:
     sync: false # skip for now; copies the most up-to-date version of the files needed to run the mask_gen mode from LTS to here
     detect_weeds: false
     unet_segment_weeds: false
-    mask_inspect: false
+    mask_inspect: true
     mask_refine: false
-  
+
+  preprocess:
+    pad_gridcrop_resize: false
+    train_val_test_split: false
+    compute_data_stats:   false
+
   train:
     - train
   

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -58,3 +58,6 @@ job:
   job_now_time: ${now:%H_%M_%S}
   job_now: ${job.job_now_date}/${job.job_now_time} 
   jobdir: ${paths.data_dir}/${job.job_now}
+
+db:
+  table_name: mask_gen_images

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -25,8 +25,9 @@ tasks: # TODO: make the other tasks bool key/values
     sync: false # skip for now; copies the most up-to-date version of the files needed to run the mask_gen mode from LTS to here
     detect_weeds: false
     unet_segment_weeds: false
-    mask_inspect: true
+    mask_inspect: false
     mask_refine: false
+    relabel_test: false
 
   preprocess:
     pad_gridcrop_resize: false

--- a/conf/mask_gen/default.yaml
+++ b/conf/mask_gen/default.yaml
@@ -11,15 +11,11 @@ refine:
   
   # Morphological operations and HSV color ranges for mask generation.
   missing_red:
-    hsv_lower: [0, 120, 70]
-    hsv_upper: [10, 255, 255]
-    hsv_lower_2: [170, 120, 70]
-    hsv_upper_2: [180, 255, 255]
+    exr_thresh: 60
+    saturation_thresh: 20
     opening_kernel_size: 0
     closing_kernel_size: 0
     erosion_kernel_size: 0
-    exr_thresh: 60  # Experimental
-    saturation_thresh: 20 # Experimental
 
   missing_white: # focus of v value
     hsv_lower: [0, 0, 240]

--- a/conf/mask_gen/default.yaml
+++ b/conf/mask_gen/default.yaml
@@ -1,16 +1,13 @@
 inspect:
   dataset_name: testing_inspect_maskgen
   port: 5050
-  only_include_tags:
+  only_tags:
     # - missing_red
   reviewer: # Leave empty, place holder for user name
 
 refine:
-  only_include_tags:
+  only_tags:
     # - missing_red
-  
-  filter_db_by_final_voxel_tags: # filters the voxel database by specific final voxel tags 
-    - good
 
   # Morphological operations and HSV color ranges for mask generation.
   missing_red:
@@ -43,7 +40,4 @@ canonical_tag_mapping: # ensures user defined tags are mapped to canonical tags 
   other: other
   ignore: ignore
   good: good
-
-remove_tags: # canonicaltags used to remove refined masks and db entries
-  # - bad
 

--- a/conf/mask_gen/default.yaml
+++ b/conf/mask_gen/default.yaml
@@ -9,6 +9,9 @@ refine:
   only_include_tags:
     # - missing_red
   
+  filter_db_by_final_voxel_tags: # filters the voxel database by specific tags
+    - good
+
   # Morphological operations and HSV color ranges for mask generation.
   missing_red:
     exr_thresh: 60
@@ -42,3 +45,4 @@ canonical_tag_mapping: # ensures user defined tags are mapped to canonical tags 
 
 remove_tags: # canonicaltags used to remove refined masks and db entries
   # - bad
+

--- a/conf/mask_gen/default.yaml
+++ b/conf/mask_gen/default.yaml
@@ -9,7 +9,7 @@ refine:
   only_include_tags:
     # - missing_red
   
-  filter_db_by_final_voxel_tags: # filters the voxel database by specific tags
+  filter_db_by_final_voxel_tags: # filters the voxel database by specific final voxel tags 
     - good
 
   # Morphological operations and HSV color ranges for mask generation.

--- a/conf/mask_gen/default.yaml
+++ b/conf/mask_gen/default.yaml
@@ -3,7 +3,7 @@ inspect:
   port: 5050
   only_include_tags:
     # - missing_red
-
+  reviewer: # Leave empty, place holder for user name
 
 refine:
   only_include_tags:
@@ -42,6 +42,7 @@ canonical_tag_mapping: # ensures user defined tags are mapped to canonical tags 
   bad: bad
   other: other
   ignore: ignore
+  good: good
 
 remove_tags: # canonicaltags used to remove refined masks and db entries
   # - bad

--- a/conf/paths/default.yaml
+++ b/conf/paths/default.yaml
@@ -40,5 +40,5 @@ unet_segmentation_model: ${paths.data_dir}/field-tools/models/unet/unet_segmenta
 # DB paths
 longterm_storage: /mnt/research-projects/r/raatwell/longterm_images3/
 agir_field_db_dir: ${paths.longterm_storage}/field-tools/agir_field_db
-agir_field_db: ${paths.agir_field_db_dir}/agir_field.db
+agir_field_db: ${paths.agir_field_db_dir}/test_agir_field.db
 agir_field_db_schema: ${paths.agir_field_db_dir}/schema.sql

--- a/conf/paths/default.yaml
+++ b/conf/paths/default.yaml
@@ -36,3 +36,9 @@ voxel_inspection_results_db: ${paths.voxel_inspection_results_dir}/${project.nam
 # model paths
 yolo_weed_detection_model: ${paths.data_dir}/field-tools/models/weed_detection/weights/best.pt
 unet_segmentation_model: ${paths.data_dir}/field-tools/models/unet/unet_segmentation.pth
+
+# DB paths
+longterm_storage: /mnt/research-projects/r/raatwell/longterm_images3/
+agir_field_db_dir: ${paths.longterm_storage}/field-tools/agir_field_db
+agir_field_db: ${paths.agir_field_db_dir}/agir_field.db
+agir_field_db_schema: ${paths.agir_field_db_dir}/schema.sql

--- a/src/mask_gen.py
+++ b/src/mask_gen.py
@@ -30,8 +30,6 @@ def main(cfg: DictConfig) -> None:
     for task, enabled in task_dict.items():
 
         if enabled:
-            log.info(f"Running task {task}")
-
             if task in TASK_REGISTRY:
                 log.info(f"Running task {task}")
                 TASK_REGISTRY[task](cfg)

--- a/src/mask_gen_utils/db_utils.py
+++ b/src/mask_gen_utils/db_utils.py
@@ -1,0 +1,173 @@
+import logging
+import sqlite3
+from typing import List, Set, Tuple
+
+from omegaconf import DictConfig
+
+# Logging configuration
+log = logging.getLogger(__name__)
+
+class InspectionDB:
+    def __init__(self, cfg: DictConfig) -> None:
+        db_path = cfg.paths.agir_field_db
+        self.table_name = cfg.db.table_name
+        log.info(f"Connecting to SQLite DB at {db_path}")
+        try:
+            self.conn = sqlite3.connect(db_path)
+            self._init_db()
+        except Exception as e:
+            log.error(f"Failed to connect or initialize DB at {db_path}: {e}")
+            raise
+
+    def _init_db(self) -> None:
+        c = self.conn.cursor()
+        try:
+            c.execute(f'''
+            CREATE TABLE IF NOT EXISTS {self.table_name} (
+                image_id TEXT PRIMARY KEY,
+                image_path TEXT,
+                mask_path TEXT,
+                refined_mask_path TEXT,
+                initial_tag TEXT,
+                final_tag TEXT,
+                tags TEXT,
+                status TEXT,
+                reviewer TEXT,
+                timestamp TEXT,
+                refine_params TEXT
+            )
+            ''')
+            
+            # Add refine_params if missing
+            c.execute(f"PRAGMA table_info({self.table_name})")
+            existing_cols = [row[1] for row in c.fetchall()]
+            if "refine_params" not in existing_cols:
+                c.execute(f"ALTER TABLE {self.table_name} ADD COLUMN refine_params TEXT")
+
+            self.conn.commit()
+        except Exception as e:
+            log.error(f"Error creating/updating DB table: {e}")
+            raise
+    
+    def add_images_bulk(self, image_info_list: List[Tuple]) -> None:
+        log.info(f"Bulk-inserting {len(image_info_list)} new images into DB")
+        c = self.conn.cursor()
+        try:
+            c.executemany(f'''
+                INSERT OR IGNORE INTO {self.table_name} (
+                    image_id, image_path, mask_path, refined_mask_path, 
+                    initial_tag, final_tag, tags, status, reviewer, timestamp
+                ) VALUES (?, ?, ?, ?, '', '', '', 'pending', '', '')
+            ''', image_info_list)
+        except Exception as e:
+            log.error(f"Bulk insert failed: {e}")
+            raise
+
+    def add_or_update_image(self, image_id: str, image_path: str, mask_path: str, refined_mask_path: str) -> None:
+        c = self.conn.cursor()
+        try:
+            c.execute(f'''
+                INSERT OR IGNORE INTO {self.table_name} (
+                    image_id, image_path, mask_path, refined_mask_path, 
+                    initial_tag, final_tag, tags, status, reviewer, timestamp
+                )
+                VALUES (?, ?, ?, ?, '', '', '', 'pending', '', '')
+            ''', (image_id, image_path, mask_path, refined_mask_path))
+        except Exception as e:
+            log.error(f"Insert failed for {image_id}: {e}")
+
+    def get_images_for_review(self, only_tags: List[str] = None) -> List[Tuple]:
+        c = self.conn.cursor()
+        try:
+            where_clauses = []
+            params = []
+
+            if only_tags:
+                tag_clauses = []
+                for tag in only_tags:
+                    tag_clauses.append("initial_tag LIKE ?")
+                    params.append(f"%{tag}%")
+                where_clauses.append("(" + " OR ".join(tag_clauses) + ")")
+
+            base_query = f"SELECT * FROM {self.table_name}"
+            if where_clauses:
+                base_query += " WHERE " + " AND ".join(where_clauses)
+
+            c.execute(base_query, params)
+            rows = c.fetchall()
+            return rows
+        except Exception as e:
+            log.error(f"Error fetching images from DB: {e}")
+            return []
+
+    def bulk_update_tags(self, updates: list) -> None:
+        """
+        updates: list of tuples:
+        (initial_tag, final_tag, tags, status, reviewer, timestamp, image_id)
+        """
+        log.info(f"Bulk updating tags for {len(updates)} images")
+        c = self.conn.cursor()
+        try:
+            c.executemany(
+                f"UPDATE {self.table_name} SET initial_tag=?, final_tag=?, tags=?, status=?, reviewer=?, timestamp=?, refine_params=? WHERE image_id=?",
+                updates
+            )
+        except Exception as e:
+            log.error(f"Bulk tag update failed: {e}")
+            raise
+
+    def get_all_image_ids(self) -> Set[str]:
+        c = self.conn.cursor()
+        try:
+            c.execute(f"SELECT image_id FROM {self.table_name}")
+            return set(row[0] for row in c.fetchall())
+        except Exception as e:
+            log.error(f"Error fetching image IDs from DB: {e}")
+            return set()
+
+    def get_images_for_refinement(self, only_tags: List[str] = None) -> List[Tuple]:
+        # Only return those with a non-empty initial_tag and not already final_tag == "good"
+        c = self.conn.cursor()
+        try:
+            base_query = f'''
+                SELECT *
+                FROM {self.table_name}
+                WHERE 
+                    (final_tag IS NULL OR final_tag != "good")
+                    AND (initial_tag IS NOT NULL AND TRIM(initial_tag) != "")
+            '''
+            params = []
+            if only_tags:
+                # Compose a WHERE clause for tags using LIKE, for safety and flexibility
+                tag_clauses = []
+                for tag in only_tags:
+                    tag_clauses.append("initial_tag LIKE ?")
+                    params.append(f"%{tag}%")
+                tag_filter = " AND (" + " OR ".join(tag_clauses) + ")"
+                base_query += tag_filter
+            c.execute(base_query, params)
+            rows = c.fetchall()
+            return rows
+        except Exception as e:
+            log.error(f"Error fetching images for refinement: {e}")
+            return []
+    
+    def close(self):
+        try:
+            self.conn.close()
+        except Exception as e:
+            log.error(f"Error closing DB: {e}")
+
+    def __enter__(self):
+        return self
+    
+    def commit(self):
+        log.info("Committing DB transaction.")
+        try:
+            self.conn.commit()
+        except Exception as e:
+            log.error(f"DB commit failed: {e}")
+            raise
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()

--- a/src/mask_gen_utils/mask_inspect.py
+++ b/src/mask_gen_utils/mask_inspect.py
@@ -262,10 +262,14 @@ class FiftyOneMaskInspector:
         Creates a new DB DataFrame from scratch and populates columns with voxel tags.
         Args:
             current_data (dict): A dictionary mapping image names to their tags."""
-
+        rows = []
         for image_name, tags_str in current_data.items():
-            self.df.loc[self.df["image_name"] == image_name, "initial_voxel_tag"] = tags_str
-            self.df["final_voxel_tag"] = ""
+            rows.append({
+                "image_name": image_name,
+                "initial_voxel_tag": tags_str,
+                "final_voxel_tag": ""
+            })
+        self.df = pd.DataFrame(rows)
 
     def _get_voxel_dataset_map(self) -> dict:
         """

--- a/src/mask_gen_utils/mask_inspect.py
+++ b/src/mask_gen_utils/mask_inspect.py
@@ -54,12 +54,20 @@ class InspectionDB:
                 tags TEXT,
                 status TEXT,
                 reviewer TEXT,
-                timestamp TEXT
+                timestamp TEXT,
+                refine_params TEXT
             )
             ''')
+            
+            # Add refine_params if missing
+            c.execute(f"PRAGMA table_info({TABLE_NAME})")
+            existing_cols = [row[1] for row in c.fetchall()]
+            if "refine_params" not in existing_cols:
+                c.execute(f"ALTER TABLE {TABLE_NAME} ADD COLUMN refine_params TEXT")
+
             self.conn.commit()
         except Exception as e:
-            log.error(f"Error creating DB table: {e}")
+            log.error(f"Error creating/updating DB table: {e}")
             raise
     
     def add_images_bulk(self, image_info_list: List[Tuple]) -> None:
@@ -122,7 +130,7 @@ class InspectionDB:
         c = self.conn.cursor()
         try:
             c.executemany(
-                f"UPDATE {TABLE_NAME} SET initial_tag=?, final_tag=?, tags=?, status=?, reviewer=?, timestamp=? WHERE image_id=?",
+                f"UPDATE {TABLE_NAME} SET initial_tag=?, final_tag=?, tags=?, status=?, reviewer=?, timestamp=?, refine_params=? WHERE image_id=?",
                 updates
             )
         except Exception as e:
@@ -290,7 +298,8 @@ class FiftyOneMaskInspector:
         for row in db_rows:
             (
                 image_id, image_path, mask_path, refined_mask_path,
-                initial_tag, final_tag, tags, status, reviewer, timestamp
+                initial_tag, final_tag, tags, status, reviewer, timestamp,
+                refine_params_str
             ) = row
 
             mask_paths_in_db.add(str(mask_path))  # Store as string for easy comparison
@@ -345,8 +354,11 @@ class FiftyOneMaskInspector:
         try:
             if self.dataset_name in fo.list_datasets():
                 log.info(f"Dataset '{self.dataset_name}' already exists. Load it.")
-                fo.load_dataset(self.dataset_name)
+                # dataset = fo.load_dataset(self.dataset_name)
+                # dataset.add_samples(samples)
+                fo.delete_dataset(self.dataset_name)  # removes registry entry
 
+            
             dataset = fo.Dataset(self.dataset_name)
             dataset.add_samples(samples)
             return dataset
@@ -408,7 +420,7 @@ class FiftyOneMaskInspector:
             image_name = Path(sample.filepath).name
             canonical_tags = self.normalize_tags(sample.tags)
             tags = set([t.lower() for t in canonical_tags if t])
-            
+            refine_params = None
             initial_tag = None
             final_tag = None
             status = None
@@ -427,7 +439,7 @@ class FiftyOneMaskInspector:
                 
             if isinstance(tags, set):
                 tags = ",".join(sorted(tags))
-            updates.append((initial_tag, final_tag, tags, status, reviewer, timestamp, image_name))
+            updates.append((initial_tag, final_tag, tags, status, reviewer, timestamp, refine_params, image_name))
         self.db.bulk_update_tags(updates)
         self.db.commit()
 

--- a/src/mask_gen_utils/mask_inspect.py
+++ b/src/mask_gen_utils/mask_inspect.py
@@ -19,10 +19,133 @@ import numpy as np
 from pathlib import Path
 import pandas as pd
 import logging
+import sqlite3
+import datetime
 
 # Logging configuration
 log = logging.getLogger(__name__)
 
+
+DB_PATH = "inspection.db"
+
+def init_db(db_path=DB_PATH):
+    conn = sqlite3.connect(db_path)
+    c = conn.cursor()
+    c.execute('''
+    CREATE TABLE IF NOT EXISTS images (
+        image_id TEXT PRIMARY KEY,
+        image_path TEXT,
+        mask_path TEXT,
+        refined_mask_path TEXT,
+        initial_tag TEXT,
+        final_tag TEXT,
+        tags TEXT,      -- optional for backward compatibility or if you want a field for "all tags"
+        status TEXT,
+        reviewer TEXT,
+        timestamp TEXT
+    )
+    ''')
+    # Add columns if running on an old DB (safe for repeated runs)
+    try:
+        c.execute("ALTER TABLE images ADD COLUMN initial_tag TEXT")
+    except sqlite3.OperationalError:
+        pass
+    try:
+        c.execute("ALTER TABLE images ADD COLUMN final_tag TEXT")
+    except sqlite3.OperationalError:
+        pass
+    conn.commit()
+    conn.close()
+
+def add_or_update_image(image_id, image_path, mask_path, refined_mask_path, db_path=DB_PATH):
+    conn = sqlite3.connect(db_path)
+    c = conn.cursor()
+    c.execute('''
+        INSERT OR IGNORE INTO images (
+            image_id, image_path, mask_path, refined_mask_path, 
+            initial_tag, final_tag, tags, status, reviewer, timestamp)
+        VALUES (?, ?, ?, ?, '', '', '', 'pending', '', '')
+    ''', (image_id, image_path, mask_path, refined_mask_path))
+    conn.commit()
+    conn.close()
+
+def get_images_for_review(tag_filter=None, db_path=DB_PATH):
+    conn = sqlite3.connect(db_path)
+    c = conn.cursor()
+    if tag_filter:
+        q = "SELECT * FROM images WHERE tags LIKE ?"
+        c.execute(q, (f"%{tag_filter}%",))
+    else:
+        q = "SELECT * FROM images"
+        c.execute(q)
+    rows = c.fetchall()
+    conn.close()
+    return rows
+
+def update_image_tags(
+    image_id, 
+    initial_tag=None, 
+    final_tag=None, 
+    tags=None, 
+    status=None, 
+    reviewer='', 
+    db_path=DB_PATH
+):
+    conn = sqlite3.connect(db_path)
+    c = conn.cursor()
+    timestamp = datetime.datetime.now().isoformat()
+    fields = []
+    values = []
+    if initial_tag is not None:
+        fields.append("initial_tag=?")
+        values.append(initial_tag)
+    if final_tag is not None:
+        fields.append("final_tag=?")
+        values.append(final_tag)
+    if tags is not None:
+        fields.append("tags=?")
+        values.append(tags)
+    if status is not None:
+        fields.append("status=?")
+        values.append(status)
+    fields.append("reviewer=?")
+    values.append(reviewer)
+    fields.append("timestamp=?")
+    values.append(timestamp)
+    values.append(image_id)
+    q = f"UPDATE images SET {', '.join(fields)} WHERE image_id=?"
+    c.execute(q, values)
+    conn.commit()
+    conn.close()
+
+def update_tags_for_sample(image_id, user_tags, reviewer='', db_path=DB_PATH):
+    """
+    Update tags for a sample:
+      - If 'good' is among the tags, update only final_tag to 'good'.
+      - Otherwise, update initial_tag to the canonical form of the tags.
+    """
+    tags = set([t.lower() for t in user_tags if t])
+    status = 'reviewed'
+
+    if "good" in tags:
+        # Only set final_tag to 'good'
+        update_image_tags(
+            image_id=image_id,
+            final_tag="good",
+            status=status,
+            reviewer=reviewer,
+            db_path=db_path
+        )
+    else:
+        # Set initial_tag to all canonical tags except 'good'
+        tag_str = ",".join(sorted(tags))
+        update_image_tags(
+            image_id=image_id,
+            initial_tag=tag_str,
+            status=status,
+            reviewer=reviewer,
+            db_path=db_path
+        )
 class FiftyOneMaskInspector:
     """
     Manages image-mask datasets and interactive inspection using FiftyOne.
@@ -45,6 +168,11 @@ class FiftyOneMaskInspector:
         # Initialize required paths from the configuration
         self.mask_gen_cutout_dir = Path(cfg.paths.mask_gen_cutout_dir)
         self.refined_masks_dir_source = Path(cfg.paths.refined_masks_dir)
+        self.db_path = "inspection.db"
+
+        init_db(self.db_path)
+        self._populate_db_with_images()
+
         self.voxel_inspection_results_dir = Path(cfg.paths.voxel_inspection_results_dir)
         self.voxel_inspection_results_dir.mkdir(parents=True, exist_ok=True)
         self.voxel_inspection_results_db = Path(cfg.paths.voxel_inspection_results_db)
@@ -55,39 +183,26 @@ class FiftyOneMaskInspector:
         self.dataset = None
         self.session = None
 
+        self.canonical_mapping = cfg.mask_gen.canonical_tag_mapping
+
         # pipeline mode
         self.mode = cfg.mode
         self.inspect_cfg = cfg.mask_gen.inspect
 
-        # load db if exists or create a new one
-        self.df = pd.read_csv(self.voxel_inspection_results_db, index_col=False) if self.voxel_inspection_results_db.exists() else pd.DataFrame(columns=["image_name", "initial_voxel_tag", "final_voxel_tag"])
-
-    def _get_mask_paths_from_db(self) -> list:
-        """
-        Gets image names from the voxel inspection results database.
-
-        Returns:
-            list: A list of image names with their corresponding mask names.
-        """
-        if not self.voxel_inspection_results_db.exists():
-            return []
-
-        image_names = []
-        for only_include_tag in self.inspect_cfg.only_include_tags:
-            # Ensure "initial_voxel_tag" column is treated as string and handle NaN values
-            matched = self.df[self.df["initial_voxel_tag"].fillna("").astype(str).str.contains(only_include_tag)]["image_name"]
-            image_names.extend(matched)
-
-        mask_paths = []
-        for image_name in image_names:
-            image_name = Path(image_name)
-            mask_path = self.mask_gen_cutout_dir / str(image_name).replace(".jpg", "_mask.png")
-            if mask_path.exists():
-                mask_paths.append(mask_path)
-            else:
-                log.warning(f"Mask file not found for {image_name}. Skipping.")
-        
-        return mask_paths
+    def _populate_db_with_images(self):
+        # Scan all masks/images and add to db if missing
+        for mask_path in self.mask_gen_cutout_dir.glob("*_mask.png"):
+            image_name = mask_path.name.replace("_mask.png", ".jpg")
+            image_path = str(self.mask_gen_cutout_dir / image_name)
+            mask_path_str = str(mask_path)
+            refined_path = str(self.refined_masks_dir_source / mask_path.name) if self.refined_masks_dir_source else ""
+            add_or_update_image(
+                image_id=image_name,
+                image_path=image_path,
+                mask_path=mask_path_str,
+                refined_mask_path=refined_path,
+                db_path=self.db_path
+            )
 
     def _create_sample_with_masks(self, mask_path: Path):
         """
@@ -118,154 +233,114 @@ class FiftyOneMaskInspector:
                 log.warning(f"Note: Refined mask not found for {image_path.name}.")
 
         return sample
-
-    def _load_samples(self) -> list:
-        """
-        Loads images and their corresponding masks into FiftyOne samples.
-
-        Returns:
-            list: A list of `fiftyone.core.sample.Sample` objects with attached segmentation masks:
-        """
-        if self.inspect_cfg.only_include_tags and self.voxel_inspection_results_db.exists():
-            mask_paths = self._get_mask_paths_from_db()
-            if not mask_paths:
-                raise ValueError("No mask paths found in the database. 'only_include_tags' is activated. Please check the voxel inspection results database.")
-        else:
-            mask_paths = sorted(self.mask_gen_cutout_dir.glob("*_mask.png"))
-        
-            if not mask_paths:
-                raise ValueError("No mask paths found. Please check the source directories or database.")
-
-        samples = []
-        for mask_path in mask_paths:
-            sample = self._create_sample_with_masks(mask_path)
-            if sample:
-                samples.append(sample)
-
-        log.info(f"Loaded {len(samples)} samples.")
-        return samples
     
-    def _create_tag_map_from_db(self) -> dict:
+    def normalize_tags(self, user_tags):
         """
-        Creates a dictionary mapping image names to their tags from the voxel inspection results database.
-
-        Returns:
-            dict: A dictionary where keys are image names and values are lists of tags.
-        """
-        tag_map = {}
-        for _, row in self.df.iterrows():
-            image_name = str(row["image_name"])
-            if pd.notna(row["final_voxel_tag"]):
-                tag = row["final_voxel_tag"]
-            elif pd.notna(row["initial_voxel_tag"]):
-                tag = str(row["initial_voxel_tag"])
-            else:
-                tag = ""
-            tags = [t.strip() for t in tag.split(",") if t.strip()]
-            tag_map[image_name] = tags
-        return tag_map
-    
-    def _create_dataset(self, samples) -> fo.Dataset:
-        """
-        Creates a FiftyOne dataset with the given samples.
-
-        If a dataset with the same name exists, it will be deleted before creation.
-        Loads tags from self.voxel_inspection_results_db if available.
+        Maps a list of user tags to canonical tags using keywords.
 
         Args:
-            samples (list): A list of FiftyOne samples.
+            user_tags (list of str): Tags as entered by user or FiftyOne UI.
+            canonical_mapping (dict): {canonical: keyword}
+
+        Returns:
+            List of canonical tags (de-duplicated).
+        """
+        normalized = set()
+        user_tags = [str(t).lower() for t in user_tags if t]
+        for canonical, keyword in self.canonical_mapping.items():
+            for user_tag in user_tags:
+                if keyword in user_tag:
+                    normalized.add(canonical)
+        return list(normalized)
+
+    def _load_samples(self, use_final_tag=False) -> list:
+        """
+        Loads FiftyOne samples from the database.
+        - If use_final_tag=True, assigns tags from 'final_tag' if present and non-empty, otherwise from 'initial_tag'.
+        - If use_final_tag=False, always uses 'initial_tag' for displayed tags.
+        """
+        db_rows = get_images_for_review(db_path=self.db_path)
+        samples = []
+        for row in db_rows:
+            (
+                image_id, image_path, mask_path, refined_mask_path,
+                initial_tag, final_tag, tags, status, reviewer, timestamp
+            ) = row
+
+            # Skip if files are missing
+            if not Path(mask_path).exists():
+                log.warning(f"Mask file not found for {image_path}. Skipping.")
+                continue
+
+            initial_mask_array = np.array(Image.open(mask_path).convert("L"), dtype=np.uint8)
+            sample = fo.Sample(filepath=image_path)
+            sample["initial_mask"] = fo.Segmentation(mask=initial_mask_array)
+
+            # Attach refined mask if present
+            if refined_mask_path and Path(refined_mask_path).exists():
+                refined_mask_array = np.array(Image.open(refined_mask_path).convert("L"), dtype=np.uint8)
+                sample["refined_mask"] = fo.Segmentation(mask=refined_mask_array)
+
+            # Determine which tag to show in UI
+            if use_final_tag and final_tag:
+                display_tags = [t.strip() for t in final_tag.split(",") if t.strip()]
+            else:
+                display_tags = [t.strip() for t in initial_tag.split(",") if t.strip()]
+
+            if display_tags:
+                sample.tags = display_tags
+
+            samples.append(sample)
+        log.info(f"Loaded {len(samples)} samples from database.")
+        return samples
+    
+    
+    def _create_dataset(self, samples=None) -> fo.Dataset:
+        """
+        Creates a FiftyOne dataset from samples defined in the SQLite DB.
+        If dataset with same name exists, it will be deleted (optionally you can skip this for persistence).
+
+        Args:
+            samples (list): Ignored—samples are loaded from DB.
 
         Returns:
             fo.Dataset: The newly created FiftyOne dataset.
         """
         log.info(f"Creating dataset: {self.dataset_name}")
+        
         if self.dataset_name in fo.list_datasets():
-            log.info(f"Dataset '{self.dataset_name}' already exists. Deleting it.")
+            log.info(f"Dataset '{self.dataset_name}' already exists. Load it.")
+            # fo.load_dataset(self.dataset_name)
             fo.delete_dataset(self.dataset_name)
+            
 
-        # Load tags from CSV if available
-        tag_map = {}
-        if self.voxel_inspection_results_db.exists():
-            tag_map = self._create_tag_map_from_db()
-            log.info(f"Loaded tags for {len(tag_map)} images from {self.voxel_inspection_results_db}")
-        else:
-            log.info(f"No existing tags found in {self.voxel_inspection_results_db}. Starting fresh.")
-
-        # Assign tags to samples
-        for sample in samples:
-            image_name = Path(sample.filepath).name
-            if image_name in tag_map:
-                sample.tags = tag_map[image_name]
-
-        dataset = fo.Dataset(self.dataset_name)
-        dataset.add_samples(samples)
-        return dataset
-
-    def _get_existing_data(self) -> dict:
-        """
-        Loads existing data from the voxel inspection results database.
-        
-        Returns:
-            dict: A dictionary mapping image names to their initial and final voxel tags.
-        """
-        existing_data = {}
-        for _, row in self.df.iterrows():
-            existing_data[row["image_name"]] = {
-                "initial_voxel_tag": row["initial_voxel_tag"],
-                "final_voxel_tag": row["final_voxel_tag"]
-            }
-        return existing_data
-
-    def _update_existing_rows(self, current_data: dict) -> None:
-        """
-        Updates self.df based on current_data if tags have changed.
-        
-        Args:
-            current_data (dict): A dictionary mapping image names to their new tags.
-        """
-        for idx, row in self.df.iterrows():
-            image_name = row["image_name"]
-            if image_name not in current_data:
+        # Query the DB for all relevant rows
+        db_rows = get_images_for_review(db_path=self.db_path)
+        fo_samples = []
+        for row in db_rows:
+            image_id, image_path, mask_path, refined_mask_path, initial_tag, final_tag, tags, status, reviewer, timestamp = row
+            # Skip if image/mask is missing
+            if not Path(image_path).exists() or not Path(mask_path).exists():
+                log.warning(f"Image or mask not found for {image_id}. Skipping.")
                 continue
 
-            new_tags = current_data[image_name]
-            old_tags = str(row["initial_voxel_tag"]) if pd.notna(row["initial_voxel_tag"]) else ""
+            # Load masks as arrays
+            initial_mask_array = np.array(Image.open(mask_path).convert("L"), dtype=np.uint8)
+            sample = fo.Sample(filepath=image_path)
+            sample["initial_mask"] = fo.Segmentation(mask=initial_mask_array)
+            # Attach refined mask if present
+            if refined_mask_path and Path(refined_mask_path).exists():
+                refined_mask_array = np.array(Image.open(refined_mask_path).convert("L"), dtype=np.uint8)
+                sample["refined_mask"] = fo.Segmentation(mask=refined_mask_array)
+            # Attach tags from DB
+            if tags:
+                sample.tags = [t.strip() for t in tags.split(",") if t.strip()]
+            fo_samples.append(sample)
 
-            if old_tags == "good":
-                continue  # Do not change 'good'
-            elif new_tags == "good":
-                self.df.at[idx, "final_voxel_tag"] = new_tags
-            elif new_tags != old_tags and new_tags != "good":
-                self.df.at[idx, "initial_voxel_tag"] = new_tags
+        dataset = fo.Dataset(self.dataset_name)
+        dataset.add_samples(fo_samples)
+        return dataset
 
-    def _append_new_rows(self, current_data: dict, existing_data: dict) -> None:
-        """
-        Appends rows to self.df for any new image names not already present.
-
-        Args:
-            current_data (dict): A dictionary mapping image names to their tags.
-            existing_data (dict): A dictionary mapping existing image names to their tags.
-        """
-        new_rows = []
-        for image_name, tags_str in current_data.items():
-            if image_name not in existing_data:
-                new_rows.append({
-                    "image_name": image_name,
-                    "initial_voxel_tag": tags_str,
-                    "final_voxel_tag": ""
-                })
-        if new_rows:
-            self.df = pd.concat([self.df, pd.DataFrame(new_rows)], ignore_index=True)
-
-    def _populate_empty_db(self, current_data: dict) -> None:
-        """
-        Creates a new DB DataFrame from scratch and populates columns with voxel tags.
-        Args:
-            current_data (dict): A dictionary mapping image names to their tags."""
-
-        for image_name, tags_str in current_data.items():
-            self.df.loc[self.df["image_name"] == image_name, "initial_voxel_tag"] = tags_str
-            self.df["final_voxel_tag"] = ""
 
     def _get_voxel_dataset_map(self) -> dict:
         """
@@ -282,60 +357,62 @@ class FiftyOneMaskInspector:
             dataset_map[image_name] = tags_str
         return dataset_map
 
-    def _handle_db(self) -> None:
+    def _handle_db(self, tag_field="initial_tag", reviewer=''):
         """
-        Handles the voxel inspection results database by updating existing rows, appending new ones, 
-        or creating a new DB if not already present.
+        After tagging in FiftyOne, update initial_tag or final_tag in DB for each sample.
+
+        Args:
+            tag_field (str): Which DB field to update, 'initial_tag' or 'final_tag'
+            reviewer (str): Name or identifier of the reviewer (optional)
         """
-        # Map image names to user defined tags from the FiftyOne dataset
-        voxel_data = self._get_voxel_dataset_map()
+        assert tag_field in ("initial_tag", "final_tag"), "tag_field must be 'initial_tag' or 'final_tag'"
 
-        # If the db exists, update existing rows and append new ones
-        if self.voxel_inspection_results_db.exists():
-            existing_data = self._get_existing_data()
-            self._update_existing_rows(voxel_data)
-            self._append_new_rows(voxel_data, existing_data)
-        else:
-            self._populate_empty_db(voxel_data)
+        for sample in self.dataset:
+            image_name = Path(sample.filepath).name
+            canonical_tags = self.normalize_tags(sample.tags)
+            update_tags_for_sample(
+                image_id=image_name,
+                user_tags=canonical_tags,
+                reviewer=reviewer,
+                db_path=self.db_path
+            )
 
-        self.df.to_csv(self.voxel_inspection_results_db, index=False)
-
-    def run_voxel_inspection(self) -> None:
+    def run_voxel_inspection(self, reviewer=''):
         """
         Runs the full inspection workflow:
-
-        - Loads samples from the filesystem.
-        - Creates a FiftyOne dataset.
-        - Launches the FiftyOne App for user-driven tagging.
-        - Waits for the session to close (Ctrl+C).
-        - Exports tags to a CSV in the results directory.
-        TODO: improve docstring for whole script
         """
         samples = self._load_samples()
         self.dataset: fo.Dataset = self._create_dataset(samples)
         self.session = fo.launch_app(self.dataset, port=self.port)
 
         try:
-            print("\n\nFollow these instructions in the FiftyOne app:\n\n"
-                "1. On the left bar, click on the LABELS tab and select desired labels: 'initial masks' or 'refined masks'\n"
-                "2. On the left bar, click on the TAGS and then select 'sample tags'\n"
-                "3. Click on the box of each image to select samples (images) of interest\n"
-                "4. Click on 'Tag samples or Labels' icon in the bar above the samples\n"
-                "5. Enter one of these tag names: 'good', 'bad', 'red_missing', 'white_missing', 'mat_present' or 'other'\n"
-                "6. Click 'ADD...' and then 'APPLY'\n"
-                "7. Repeat steps 2–6 for additional tags\n"
-                "8. Press Ctrl+C in the terminal to end the session and save the tags\n")
+            print("\nTag your images, then close the FiftyOne app or press Ctrl+C here to save.")
             self.session.wait()
         except KeyboardInterrupt:
             print("\nSession manually interrupted by user.")
         finally:
             self.session.refresh()
             self.session.close()
+            self._update_sqlite_db_with_tags(reviewer=reviewer)
             print("Session closed.")
 
         # Save the voxel inspection results
         self._handle_db()
         log.info(f"Tags saved to database: {self.voxel_inspection_results_db}")
+
+    def _update_sqlite_db_with_tags(self, reviewer='', tag_field="initial_tag"):
+        """
+        After the session, updates SQLite DB with tags for all samples in the dataset.
+        """
+        for sample in self.dataset:
+            image_name = Path(sample.filepath).name
+            canonical_tags = self.normalize_tags(sample.tags)
+            update_tags_for_sample(
+                image_id=image_name,
+                user_tags=canonical_tags,
+                reviewer=reviewer,
+                db_path=self.db_path
+            )
 
 def main(cfg: DictConfig) -> None:
     """
@@ -344,5 +421,6 @@ def main(cfg: DictConfig) -> None:
     Args:
         cfg (DictConfig): A configuration object containing all necessary paths and parameters.
     """
+
     inspector = FiftyOneMaskInspector(cfg)
     inspector.run_voxel_inspection()

--- a/src/mask_gen_utils/mask_inspect.py
+++ b/src/mask_gen_utils/mask_inspect.py
@@ -25,7 +25,7 @@ import pandas as pd
 import logging
 import sqlite3
 import datetime
-from typing import List, Dict, Set, Tuple
+from typing import List, Dict, Optional, Set, Tuple
 
 # Logging configuration
 log = logging.getLogger(__name__)
@@ -92,11 +92,24 @@ class InspectionDB:
         except Exception as e:
             log.error(f"Insert failed for {image_id}: {e}")
 
-    def get_images_for_review(self) -> List[Tuple]:
+    def get_images_for_review(self, only_tags: List[str] = None) -> List[Tuple]:
         c = self.conn.cursor()
         try:
-            q = "SELECT * FROM images"
-            c.execute(q)
+            where_clauses = []
+            params = []
+
+            if only_tags:
+                tag_clauses = []
+                for tag in only_tags:
+                    tag_clauses.append("initial_tag LIKE ?")
+                    params.append(f"%{tag}%")
+                where_clauses.append("(" + " OR ".join(tag_clauses) + ")")
+
+            base_query = "SELECT * FROM images"
+            if where_clauses:
+                base_query += " WHERE " + " AND ".join(where_clauses)
+
+            c.execute(base_query, params)
             rows = c.fetchall()
             return rows
         except Exception as e:
@@ -128,6 +141,33 @@ class InspectionDB:
             log.error(f"Error fetching image IDs from DB: {e}")
             return set()
 
+    def get_images_for_refinement(self, only_tags: List[str] = None) -> List[Tuple]:
+        # Only return those with a non-empty initial_tag and not already final_tag == "good"
+        c = self.conn.cursor()
+        try:
+            base_query = '''
+                SELECT *
+                FROM images
+                WHERE 
+                    (final_tag IS NULL OR final_tag != "good")
+                    AND (initial_tag IS NOT NULL AND TRIM(initial_tag) != "")
+            '''
+            params = []
+            if only_tags:
+                # Compose a WHERE clause for tags using LIKE, for safety and flexibility
+                tag_clauses = []
+                for tag in only_tags:
+                    tag_clauses.append("initial_tag LIKE ?")
+                    params.append(f"%{tag}%")
+                tag_filter = " AND (" + " OR ".join(tag_clauses) + ")"
+                base_query += tag_filter
+            c.execute(base_query, params)
+            rows = c.fetchall()
+            return rows
+        except Exception as e:
+            log.error(f"Error fetching images for refinement: {e}")
+            return []
+    
     def close(self):
         try:
             self.conn.close()
@@ -188,11 +228,7 @@ class FiftyOneMaskInspector:
         # Reviewer name for tagging
         self.reviewer = os.getenv("USER")
 
-        # Refine parameters: 
-        refine_cfg = cfg.mask_gen.inspect
-        refine_params = OmegaConf.to_container(refine_cfg, resolve=True)
-        refine_params_json = json.dumps(refine_params)
-
+        self.only_tags = cfg.mask_gen.inspect.only_tags
 
     def _populate_db_with_images(self) -> None:
         
@@ -209,7 +245,7 @@ class FiftyOneMaskInspector:
                 mask_path_str = str(mask_path)
                 refined_path = str(self.refined_masks_dir / mask_path.name) if self.refined_masks_dir else ""
                 masks_to_add.append((image_name, image_path, mask_path_str, refined_path))
-            if len(masks_to_add) <= 3:
+            if 0 < len(masks_to_add) <= 3:
                 log.info(f"Adding {len(masks_to_add)} images one by one to DB")
                 for entry in masks_to_add:
                     try:
@@ -250,7 +286,7 @@ class FiftyOneMaskInspector:
         Returns:
             list: A list of FiftyOne samples created from the database entries.
         """
-        db_rows = self.db.get_images_for_review()
+        db_rows = self.db.get_images_for_review(only_tags=self.only_tags)
         samples = []
         mask_paths_in_db = set()  # Track mask paths for deduplication
 

--- a/src/mask_gen_utils/mask_inspect.py
+++ b/src/mask_gen_utils/mask_inspect.py
@@ -69,7 +69,7 @@ class FiftyOneMaskInspector:
         Returns:
             list: A list of strings representing image names and their corresponding mask tags.
         """
-        return sorted(self.mask_gen_cutout_dir.glob("*.jpg"))
+        return sorted(self.mask_gen_cutout_dir.glob("*_mask.png"))
 
     def get_mask_paths_from_db(self) -> list:
         """
@@ -86,8 +86,8 @@ class FiftyOneMaskInspector:
 
         image_names = []
         for only_include_tag in self.inspect_cfg.only_include_tags:
-
-            matched = df[df["voxel tags"].str.contains(only_include_tag, na=False)]["image_name"]
+            # Ensure "voxel tags" column is treated as string and handle NaN values
+            matched = df[df["voxel tags"].fillna("").astype(str).str.contains(only_include_tag)]["image_name"]
             image_names.extend(matched)
 
         mask_paths = []
@@ -111,17 +111,19 @@ class FiftyOneMaskInspector:
                   - "prediction": from refined_masks `.png` files, if available
         """
         
-        if self.inspect_cfg.only_include_tags:
+        if self.inspect_cfg.only_include_tags and self.voxel_inspection_results_db.exists():
             mask_paths = self.get_mask_paths_from_db()
+            if not mask_paths:
+                raise ValueError("No mask paths found in the database. 'only_include_tags' is activated. Please check the voxel inspection results database.")
         else:
             mask_paths = self.get_mask_paths_from_src()
         
-        if not mask_paths:
-            raise ValueError("No mask paths found. Please check the source directories or database.")
+            if not mask_paths:
+                raise ValueError("No mask paths found. Please check the source directories or database.")
 
         samples = []
         for initial_mask_path in mask_paths:
-            image_name = initial_mask_path.stem.replace("_mask", ".jpg")
+            image_name = initial_mask_path.name.replace("_mask.png", ".jpg")
             if not initial_mask_path.exists():
                 log.warning(f"Warning: Initial mask not found for {image_name}. Skipping.")
                 continue

--- a/src/mask_gen_utils/mask_inspect.py
+++ b/src/mask_gen_utils/mask_inspect.py
@@ -203,7 +203,7 @@ class FiftyOneMaskInspector:
 
     def _load_existing_data(self) -> dict:
         """
-        Loads the existing CSV into self.df and returns a map of existing data.
+        Loads existing data from the voxel inspection results database.
         
         Returns:
             dict: A dictionary mapping image names to their initial and final voxel tags.

--- a/src/mask_gen_utils/mask_inspect.py
+++ b/src/mask_gen_utils/mask_inspect.py
@@ -60,7 +60,7 @@ class FiftyOneMaskInspector:
         self.inspect_cfg = cfg.mask_gen.inspect
 
         # load db if exists or create a new one
-        self.df = pd.read_csv(self.voxel_inspection_results_db, index_col=False) if self.voxel_inspection_results_db.exists() else pd.DataFrame()
+        self.df = pd.read_csv(self.voxel_inspection_results_db, index_col=False) if self.voxel_inspection_results_db.exists() else pd.DataFrame(columns=["image_name", "initial_voxel_tag", "final_voxel_tag"])
 
     def _get_mask_paths_from_db(self) -> list:
         """
@@ -201,7 +201,7 @@ class FiftyOneMaskInspector:
         dataset.add_samples(samples)
         return dataset
 
-    def _load_existing_data(self) -> dict:
+    def _get_existing_data(self) -> dict:
         """
         Loads existing data from the voxel inspection results database.
         
@@ -257,23 +257,19 @@ class FiftyOneMaskInspector:
         if new_rows:
             self.df = pd.concat([self.df, pd.DataFrame(new_rows)], ignore_index=True)
 
-    def _create_new_dataframe(self, current_data: dict) -> None:
+    def _populate_empty_db(self, current_data: dict) -> None:
         """
-        Creates a new DataFrame from scratch when no CSV exists.
+        Creates a new DB DataFrame from scratch and populates columns with voxel tags.
         Args:
             current_data (dict): A dictionary mapping image names to their tags."""
-        self.df = pd.DataFrame([
-            {
-                "image_name": image_name,
-                "initial_voxel_tag": tags_str,
-                "final_voxel_tag": ""
-            }
-            for image_name, tags_str in current_data.items()
-        ])
 
-    def _get_current_dataset_map(self) -> dict:
+        for image_name, tags_str in current_data.items():
+            self.df.loc[self.df["image_name"] == image_name, "initial_voxel_tag"] = tags_str
+            self.df["final_voxel_tag"] = ""
+
+    def _get_voxel_dataset_map(self) -> dict:
         """
-        Creates a dictionary of image_name -> tags from self.dataset.
+        Creates a dictionary of image_name -> user tags from self.dataset.
 
         Returns:
             dict: A dictionary where keys are image filenames and values are comma-separated tag strings.
@@ -286,27 +282,23 @@ class FiftyOneMaskInspector:
             dataset_map[image_name] = tags_str
         return dataset_map
 
-    def _save_tags_to_db(self, output_csv: Path) -> None:
+    def _handle_db(self) -> None:
         """
-        Writes updated tagging information from the FiftyOne session back to the voxel inspection CSV.
-
-        - Updates existing entries if tags have changed (except for 'good' which is preserved).
-        - Appends any new image entries not already in the CSV.
-
-        Args:
-            output_csv (Path): Destination path for the updated voxel inspection CSV.
+        Handles the voxel inspection results database by updating existing rows, appending new ones, 
+        or creating a new DB if not already present.
         """
-        output_csv = Path(output_csv)
-        current_data = self._get_current_dataset_map()
+        # Map image names to user defined tags from the FiftyOne dataset
+        voxel_data = self._get_voxel_dataset_map()
 
-        if output_csv.exists():
-            existing_data = self._load_existing_data()
-            self._update_existing_rows(current_data)
-            self._append_new_rows(current_data, existing_data)
+        # If the db exists, update existing rows and append new ones
+        if self.voxel_inspection_results_db.exists():
+            existing_data = self._get_existing_data()
+            self._update_existing_rows(voxel_data)
+            self._append_new_rows(voxel_data, existing_data)
         else:
-            self._create_new_dataframe(current_data)
+            self._populate_empty_db(voxel_data)
 
-        self.df.to_csv(output_csv, index=False)
+        self.df.to_csv(self.voxel_inspection_results_db, index=False)
 
     def run_voxel_inspection(self) -> None:
         """
@@ -342,7 +334,7 @@ class FiftyOneMaskInspector:
             print("Session closed.")
 
         # Save the voxel inspection results
-        self._save_tags_to_db(self.voxel_inspection_results_db)
+        self._handle_db()
         log.info(f"Tags saved to database: {self.voxel_inspection_results_db}")
 
 def main(cfg: DictConfig) -> None:

--- a/src/mask_gen_utils/mask_inspect.py
+++ b/src/mask_gen_utils/mask_inspect.py
@@ -24,174 +24,13 @@ import sqlite3
 import datetime
 from typing import List, Dict, Set, Tuple
 
+from src.mask_gen_utils.db_utils import InspectionDB
+
 # Logging configuration
 log = logging.getLogger(__name__)
 
 
 TABLE_NAME = "mask_gen_images"
-
-class InspectionDB:
-    def __init__(self, db_path: str) -> None:
-        log.info(f"Connecting to SQLite DB at {db_path}")
-        try:
-            self.conn = sqlite3.connect(db_path)
-            self._init_db()
-        except Exception as e:
-            log.error(f"Failed to connect or initialize DB at {db_path}: {e}")
-            raise
-
-    def _init_db(self) -> None:
-        c = self.conn.cursor()
-        try:
-            c.execute(f'''
-            CREATE TABLE IF NOT EXISTS {TABLE_NAME} (
-                image_id TEXT PRIMARY KEY,
-                image_path TEXT,
-                mask_path TEXT,
-                refined_mask_path TEXT,
-                initial_tag TEXT,
-                final_tag TEXT,
-                tags TEXT,
-                status TEXT,
-                reviewer TEXT,
-                timestamp TEXT,
-                refine_params TEXT
-            )
-            ''')
-            
-            # Add refine_params if missing
-            c.execute(f"PRAGMA table_info({TABLE_NAME})")
-            existing_cols = [row[1] for row in c.fetchall()]
-            if "refine_params" not in existing_cols:
-                c.execute(f"ALTER TABLE {TABLE_NAME} ADD COLUMN refine_params TEXT")
-
-            self.conn.commit()
-        except Exception as e:
-            log.error(f"Error creating/updating DB table: {e}")
-            raise
-    
-    def add_images_bulk(self, image_info_list: List[Tuple]) -> None:
-        log.info(f"Bulk-inserting {len(image_info_list)} new images into DB")
-        c = self.conn.cursor()
-        try:
-            c.executemany(f'''
-                INSERT OR IGNORE INTO {TABLE_NAME} (
-                    image_id, image_path, mask_path, refined_mask_path, 
-                    initial_tag, final_tag, tags, status, reviewer, timestamp
-                ) VALUES (?, ?, ?, ?, '', '', '', 'pending', '', '')
-            ''', image_info_list)
-        except Exception as e:
-            log.error(f"Bulk insert failed: {e}")
-            raise
-
-    def add_or_update_image(self, image_id: str, image_path: str, mask_path: str, refined_mask_path: str) -> None:
-        c = self.conn.cursor()
-        try:
-            c.execute(f'''
-                INSERT OR IGNORE INTO {TABLE_NAME} (
-                    image_id, image_path, mask_path, refined_mask_path, 
-                    initial_tag, final_tag, tags, status, reviewer, timestamp
-                )
-                VALUES (?, ?, ?, ?, '', '', '', 'pending', '', '')
-            ''', (image_id, image_path, mask_path, refined_mask_path))
-        except Exception as e:
-            log.error(f"Insert failed for {image_id}: {e}")
-
-    def get_images_for_review(self, only_tags: List[str] = None) -> List[Tuple]:
-        c = self.conn.cursor()
-        try:
-            where_clauses = []
-            params = []
-
-            if only_tags:
-                tag_clauses = []
-                for tag in only_tags:
-                    tag_clauses.append("initial_tag LIKE ?")
-                    params.append(f"%{tag}%")
-                where_clauses.append("(" + " OR ".join(tag_clauses) + ")")
-
-            base_query = f"SELECT * FROM {TABLE_NAME}"
-            if where_clauses:
-                base_query += " WHERE " + " AND ".join(where_clauses)
-
-            c.execute(base_query, params)
-            rows = c.fetchall()
-            return rows
-        except Exception as e:
-            log.error(f"Error fetching images from DB: {e}")
-            return []
-
-    def bulk_update_tags(self, updates: list) -> None:
-        """
-        updates: list of tuples:
-        (initial_tag, final_tag, tags, status, reviewer, timestamp, image_id)
-        """
-        log.info(f"Bulk updating tags for {len(updates)} images")
-        c = self.conn.cursor()
-        try:
-            c.executemany(
-                f"UPDATE {TABLE_NAME} SET initial_tag=?, final_tag=?, tags=?, status=?, reviewer=?, timestamp=?, refine_params=? WHERE image_id=?",
-                updates
-            )
-        except Exception as e:
-            log.error(f"Bulk tag update failed: {e}")
-            raise
-
-    def get_all_image_ids(self) -> Set[str]:
-        c = self.conn.cursor()
-        try:
-            c.execute(f"SELECT image_id FROM {TABLE_NAME}")
-            return set(row[0] for row in c.fetchall())
-        except Exception as e:
-            log.error(f"Error fetching image IDs from DB: {e}")
-            return set()
-
-    def get_images_for_refinement(self, only_tags: List[str] = None) -> List[Tuple]:
-        # Only return those with a non-empty initial_tag and not already final_tag == "good"
-        c = self.conn.cursor()
-        try:
-            base_query = f'''
-                SELECT *
-                FROM {TABLE_NAME}
-                WHERE 
-                    (final_tag IS NULL OR final_tag != "good")
-                    AND (initial_tag IS NOT NULL AND TRIM(initial_tag) != "")
-            '''
-            params = []
-            if only_tags:
-                # Compose a WHERE clause for tags using LIKE, for safety and flexibility
-                tag_clauses = []
-                for tag in only_tags:
-                    tag_clauses.append("initial_tag LIKE ?")
-                    params.append(f"%{tag}%")
-                tag_filter = " AND (" + " OR ".join(tag_clauses) + ")"
-                base_query += tag_filter
-            c.execute(base_query, params)
-            rows = c.fetchall()
-            return rows
-        except Exception as e:
-            log.error(f"Error fetching images for refinement: {e}")
-            return []
-    
-    def close(self):
-        try:
-            self.conn.close()
-        except Exception as e:
-            log.error(f"Error closing DB: {e}")
-
-    def __enter__(self):
-        return self
-    
-    def commit(self):
-        log.info("Committing DB transaction.")
-        try:
-            self.conn.commit()
-        except Exception as e:
-            log.error(f"DB commit failed: {e}")
-            raise
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.close()
 
 class FiftyOneMaskInspector:
     """
@@ -218,7 +57,7 @@ class FiftyOneMaskInspector:
         self.db_path = cfg.paths.agir_field_db
 
         # Use persistent DB connection
-        self.db = InspectionDB(self.db_path)
+        self.db = InspectionDB(cfg)
         self._populate_db_with_images()
 
         # Configuration parameters for FiftyOne Voxel

--- a/src/mask_gen_utils/mask_inspect.py
+++ b/src/mask_gen_utils/mask_inspect.py
@@ -1,151 +1,153 @@
 """
-Voxel Inspection and Image Tagging Script
------------------------------------------
+Voxel Mask Inspection and Tagging Pipeline
+------------------------------------------
 
-This script facilitates the inspection and tagging of image segmentation masks using the FiftyOne toolkit. It is designed for workflows that involve manual validation or selection of image-mask pairs, such as in medical imaging, 3D modeling, or computer vision QA processes.
+This script provides an automated pipeline for the inspection, validation, and interactive tagging of image segmentation masks using the FiftyOne toolkit.
 
-Functionality:
-- Loads `.jpg` images and their corresponding mask files (`_mask.png` for initial masks and `.png` for refined masks).
-- Wraps these files into FiftyOne samples with labeled segmentation fields.
-- Launches the FiftyOne App for interactive selection and tagging.
-- Saves the selected image names and associated tags into a CSV file.
-- Moves tagged "good" images to a long-term storage (LTS) location for future use.
+Key Features:
+- Automatically detects and adds new image/mask pairs to a persistent SQLite database.
+- Loads `.jpg` images and their corresponding mask files (`*_mask.png` for initial masks and optionally refined masks).
+- Wraps each image and its mask(s) into FiftyOne samples for visualization and manual review.
+- Launches the FiftyOne App for inspection and tagging of segmentation masks.
+- Tracks image status and user-generated tags in the database.
+- (Not implemented) Moves images tagged as 'good' to a long-term storage location as needed. TODO: Implement this in mask_refine.py.
 """
 
+import os
 import fiftyone as fo
 from omegaconf import DictConfig
+from omegaconf import OmegaConf
 from PIL import Image
+import json
 import numpy as np
 from pathlib import Path
 import pandas as pd
 import logging
 import sqlite3
 import datetime
+from typing import List, Dict, Set, Tuple
 
 # Logging configuration
 log = logging.getLogger(__name__)
 
 
-DB_PATH = "inspection.db"
+DB_PATH = "inspection.db" # TODO: pull from cfg.paths.db_path or similar
 
-def init_db(db_path=DB_PATH):
-    conn = sqlite3.connect(db_path)
-    c = conn.cursor()
-    c.execute('''
-    CREATE TABLE IF NOT EXISTS images (
-        image_id TEXT PRIMARY KEY,
-        image_path TEXT,
-        mask_path TEXT,
-        refined_mask_path TEXT,
-        initial_tag TEXT,
-        final_tag TEXT,
-        tags TEXT,      -- optional for backward compatibility or if you want a field for "all tags"
-        status TEXT,
-        reviewer TEXT,
-        timestamp TEXT
-    )
-    ''')
-    # Add columns if running on an old DB (safe for repeated runs)
-    try:
-        c.execute("ALTER TABLE images ADD COLUMN initial_tag TEXT")
-    except sqlite3.OperationalError:
-        pass
-    try:
-        c.execute("ALTER TABLE images ADD COLUMN final_tag TEXT")
-    except sqlite3.OperationalError:
-        pass
-    conn.commit()
-    conn.close()
+class InspectionDB:
+    def __init__(self, db_path: str) -> None:
+        log.info(f"Connecting to SQLite DB at {db_path}")
+        try:
+            self.conn = sqlite3.connect(db_path)
+            self._init_db()
+        except Exception as e:
+            log.error(f"Failed to connect or initialize DB at {db_path}: {e}")
+            raise
 
-def add_or_update_image(image_id, image_path, mask_path, refined_mask_path, db_path=DB_PATH):
-    conn = sqlite3.connect(db_path)
-    c = conn.cursor()
-    c.execute('''
-        INSERT OR IGNORE INTO images (
-            image_id, image_path, mask_path, refined_mask_path, 
-            initial_tag, final_tag, tags, status, reviewer, timestamp)
-        VALUES (?, ?, ?, ?, '', '', '', 'pending', '', '')
-    ''', (image_id, image_path, mask_path, refined_mask_path))
-    conn.commit()
-    conn.close()
+    def _init_db(self) -> None:
+        c = self.conn.cursor()
+        try:
+            c.execute('''
+            CREATE TABLE IF NOT EXISTS images (
+                image_id TEXT PRIMARY KEY,
+                image_path TEXT,
+                mask_path TEXT,
+                refined_mask_path TEXT,
+                initial_tag TEXT,
+                final_tag TEXT,
+                tags TEXT,
+                status TEXT,
+                reviewer TEXT,
+                timestamp TEXT
+            )
+            ''')
+            self.conn.commit()
+        except Exception as e:
+            log.error(f"Error creating DB table: {e}")
+            raise
+    
+    def add_images_bulk(self, image_info_list: List[Tuple]) -> None:
+        log.info(f"Bulk-inserting {len(image_info_list)} new images into DB")
+        c = self.conn.cursor()
+        try:
+            c.executemany('''
+                INSERT OR IGNORE INTO images (
+                    image_id, image_path, mask_path, refined_mask_path, 
+                    initial_tag, final_tag, tags, status, reviewer, timestamp
+                ) VALUES (?, ?, ?, ?, '', '', '', 'pending', '', '')
+            ''', image_info_list)
+        except Exception as e:
+            log.error(f"Bulk insert failed: {e}")
+            raise
 
-def get_images_for_review(tag_filter=None, db_path=DB_PATH):
-    conn = sqlite3.connect(db_path)
-    c = conn.cursor()
-    if tag_filter:
-        q = "SELECT * FROM images WHERE tags LIKE ?"
-        c.execute(q, (f"%{tag_filter}%",))
-    else:
-        q = "SELECT * FROM images"
-        c.execute(q)
-    rows = c.fetchall()
-    conn.close()
-    return rows
+    def add_or_update_image(self, image_id: str, image_path: str, mask_path: str, refined_mask_path: str) -> None:
+        c = self.conn.cursor()
+        try:
+            c.execute('''
+                INSERT OR IGNORE INTO images (
+                    image_id, image_path, mask_path, refined_mask_path, 
+                    initial_tag, final_tag, tags, status, reviewer, timestamp
+                )
+                VALUES (?, ?, ?, ?, '', '', '', 'pending', '', '')
+            ''', (image_id, image_path, mask_path, refined_mask_path))
+        except Exception as e:
+            log.error(f"Insert failed for {image_id}: {e}")
 
-def update_image_tags(
-    image_id, 
-    initial_tag=None, 
-    final_tag=None, 
-    tags=None, 
-    status=None, 
-    reviewer='', 
-    db_path=DB_PATH
-):
-    conn = sqlite3.connect(db_path)
-    c = conn.cursor()
-    timestamp = datetime.datetime.now().isoformat()
-    fields = []
-    values = []
-    if initial_tag is not None:
-        fields.append("initial_tag=?")
-        values.append(initial_tag)
-    if final_tag is not None:
-        fields.append("final_tag=?")
-        values.append(final_tag)
-    if tags is not None:
-        fields.append("tags=?")
-        values.append(tags)
-    if status is not None:
-        fields.append("status=?")
-        values.append(status)
-    fields.append("reviewer=?")
-    values.append(reviewer)
-    fields.append("timestamp=?")
-    values.append(timestamp)
-    values.append(image_id)
-    q = f"UPDATE images SET {', '.join(fields)} WHERE image_id=?"
-    c.execute(q, values)
-    conn.commit()
-    conn.close()
+    def get_images_for_review(self) -> List[Tuple]:
+        c = self.conn.cursor()
+        try:
+            q = "SELECT * FROM images"
+            c.execute(q)
+            rows = c.fetchall()
+            return rows
+        except Exception as e:
+            log.error(f"Error fetching images from DB: {e}")
+            return []
 
-def update_tags_for_sample(image_id, user_tags, reviewer='', db_path=DB_PATH):
-    """
-    Update tags for a sample:
-      - If 'good' is among the tags, update only final_tag to 'good'.
-      - Otherwise, update initial_tag to the canonical form of the tags.
-    """
-    tags = set([t.lower() for t in user_tags if t])
-    status = 'reviewed'
+    def bulk_update_tags(self, updates: list) -> None:
+        """
+        updates: list of tuples:
+        (initial_tag, final_tag, tags, status, reviewer, timestamp, image_id)
+        """
+        log.info(f"Bulk updating tags for {len(updates)} images")
+        c = self.conn.cursor()
+        try:
+            c.executemany(
+                "UPDATE images SET initial_tag=?, final_tag=?, tags=?, status=?, reviewer=?, timestamp=? WHERE image_id=?",
+                updates
+            )
+        except Exception as e:
+            log.error(f"Bulk tag update failed: {e}")
+            raise
 
-    if "good" in tags:
-        # Only set final_tag to 'good'
-        update_image_tags(
-            image_id=image_id,
-            final_tag="good",
-            status=status,
-            reviewer=reviewer,
-            db_path=db_path
-        )
-    else:
-        # Set initial_tag to all canonical tags except 'good'
-        tag_str = ",".join(sorted(tags))
-        update_image_tags(
-            image_id=image_id,
-            initial_tag=tag_str,
-            status=status,
-            reviewer=reviewer,
-            db_path=db_path
-        )
+    def get_all_image_ids(self) -> Set[str]:
+        c = self.conn.cursor()
+        try:
+            c.execute("SELECT image_id FROM images")
+            return set(row[0] for row in c.fetchall())
+        except Exception as e:
+            log.error(f"Error fetching image IDs from DB: {e}")
+            return set()
+
+    def close(self):
+        try:
+            self.conn.close()
+        except Exception as e:
+            log.error(f"Error closing DB: {e}")
+
+    def __enter__(self):
+        return self
+    
+    def commit(self):
+        log.info("Committing DB transaction.")
+        try:
+            self.conn.commit()
+        except Exception as e:
+            log.error(f"DB commit failed: {e}")
+            raise
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
 class FiftyOneMaskInspector:
     """
     Manages image-mask datasets and interactive inspection using FiftyOne.
@@ -167,74 +169,62 @@ class FiftyOneMaskInspector:
         """
         # Initialize required paths from the configuration
         self.mask_gen_cutout_dir = Path(cfg.paths.mask_gen_cutout_dir)
-        self.refined_masks_dir_source = Path(cfg.paths.refined_masks_dir)
-        self.db_path = "inspection.db"
+        self.refined_masks_dir = Path(cfg.paths.refined_masks_dir)
+        self.db_path = DB_PATH # TODO: pull from cfg.paths.db_path or similar
 
-        init_db(self.db_path)
+        # Use persistent DB connection
+        self.db = InspectionDB(self.db_path)
         self._populate_db_with_images()
-
-        self.voxel_inspection_results_dir = Path(cfg.paths.voxel_inspection_results_dir)
-        self.voxel_inspection_results_dir.mkdir(parents=True, exist_ok=True)
-        self.voxel_inspection_results_db = Path(cfg.paths.voxel_inspection_results_db)
 
         # Configuration parameters for FiftyOne Voxel
         self.port = cfg.mask_gen.inspect.port
         self.dataset_name = cfg.mask_gen.inspect.dataset_name
-        self.dataset = None
-        self.session = None
+        self.dataset = None # Place holder for FiftyOne dataset
+        self.session = None # Place holder for FiftyOne session
 
+        # Canonical tag mapping for user-defined tags
         self.canonical_mapping = cfg.mask_gen.canonical_tag_mapping
 
-        # pipeline mode
-        self.mode = cfg.mode
-        self.inspect_cfg = cfg.mask_gen.inspect
+        # Reviewer name for tagging
+        self.reviewer = os.getenv("USER")
 
-    def _populate_db_with_images(self):
-        # Scan all masks/images and add to db if missing
-        for mask_path in self.mask_gen_cutout_dir.glob("*_mask.png"):
-            image_name = mask_path.name.replace("_mask.png", ".jpg")
-            image_path = str(self.mask_gen_cutout_dir / image_name)
-            mask_path_str = str(mask_path)
-            refined_path = str(self.refined_masks_dir_source / mask_path.name) if self.refined_masks_dir_source else ""
-            add_or_update_image(
-                image_id=image_name,
-                image_path=image_path,
-                mask_path=mask_path_str,
-                refined_mask_path=refined_path,
-                db_path=self.db_path
-            )
+        # Refine parameters: 
+        refine_cfg = cfg.mask_gen.inspect
+        refine_params = OmegaConf.to_container(refine_cfg, resolve=True)
+        refine_params_json = json.dumps(refine_params)
 
-    def _create_sample_with_masks(self, mask_path: Path):
-        """
-        Creates a FiftyOne sample with initial and refined masks (if available).
 
-        Args:
-            mask_path (Path): Path to the initial mask image.
-
-        Returns:
-            fo.Sample or None: The sample object or None if the mask is invalid.
-        """
-        image_name = mask_path.name.replace("_mask.png", ".jpg")
-        if not mask_path.exists():
-            log.warning(f"Warning: Initial mask not found for {image_name}. Skipping.")
-            return None
-
-        initial_mask_array = np.array(Image.open(mask_path).convert("L"), dtype=np.uint8)
-        image_path = self.mask_gen_cutout_dir / image_name
-        sample = fo.Sample(filepath=str(image_path))
-        sample["initial_mask"] = fo.Segmentation(mask=initial_mask_array)
-
-        if self.refined_masks_dir_source:
-            refined_mask_path = self.refined_masks_dir_source / f"{Path(image_name).stem}_mask.png"
-            if refined_mask_path.exists():
-                refined_mask_array = np.array(Image.open(refined_mask_path).convert("L"), dtype=np.uint8)
-                sample["refined_mask"] = fo.Segmentation(mask=refined_mask_array)
+    def _populate_db_with_images(self) -> None:
+        
+        try:
+            log.info("Populating DB with missing images...")
+            existing_ids = self.db.get_all_image_ids()
+            masks_to_add = []
+            for mask_path in self.mask_gen_cutout_dir.glob("*_mask.png"):
+                image_name = mask_path.name.replace("_mask.png", ".jpg")
+                if image_name in existing_ids:
+                    log.debug(f"Skipping {image_name} (already in DB)")
+                    continue
+                image_path = str(self.mask_gen_cutout_dir / image_name)
+                mask_path_str = str(mask_path)
+                refined_path = str(self.refined_masks_dir / mask_path.name) if self.refined_masks_dir else ""
+                masks_to_add.append((image_name, image_path, mask_path_str, refined_path))
+            if len(masks_to_add) <= 3:
+                log.info(f"Adding {len(masks_to_add)} images one by one to DB")
+                for entry in masks_to_add:
+                    try:
+                        self.db.add_or_update_image(*entry)
+                    except Exception as e:
+                        log.error(f"Error adding image {entry[0]}: {e}")
+            elif masks_to_add:
+                log.info(f"Adding {len(masks_to_add)} images in bulk to DB")
+                self.db.add_images_bulk(masks_to_add)
             else:
-                log.warning(f"Note: Refined mask not found for {image_path.name}.")
+                log.info("No new images to add to the database.")
+        except Exception as e:
+            log.error(f"Error populating DB with images: {e}")
 
-        return sample
-    
-    def normalize_tags(self, user_tags):
+    def normalize_tags(self, user_tags: List[str]) -> List[str]:
         """
         Maps a list of user tags to canonical tags using keywords.
 
@@ -251,51 +241,63 @@ class FiftyOneMaskInspector:
             for user_tag in user_tags:
                 if keyword in user_tag:
                     normalized.add(canonical)
+        log.debug(f"Normalized tags {user_tags} -> {list(normalized)}")
         return list(normalized)
 
-    def _load_samples(self, use_final_tag=False) -> list:
+    def _load_samples(self) -> List[fo.Sample]:
         """
         Loads FiftyOne samples from the database.
-        - If use_final_tag=True, assigns tags from 'final_tag' if present and non-empty, otherwise from 'initial_tag'.
-        - If use_final_tag=False, always uses 'initial_tag' for displayed tags.
+        Returns:
+            list: A list of FiftyOne samples created from the database entries.
         """
-        db_rows = get_images_for_review(db_path=self.db_path)
+        db_rows = self.db.get_images_for_review()
         samples = []
+        mask_paths_in_db = set()  # Track mask paths for deduplication
+
         for row in db_rows:
             (
                 image_id, image_path, mask_path, refined_mask_path,
                 initial_tag, final_tag, tags, status, reviewer, timestamp
             ) = row
 
+            mask_paths_in_db.add(str(mask_path))  # Store as string for easy comparison
+
             # Skip if files are missing
             if not Path(mask_path).exists():
                 log.warning(f"Mask file not found for {image_path}. Skipping.")
                 continue
 
+            # Load the initial mask and create a sample
             initial_mask_array = np.array(Image.open(mask_path).convert("L"), dtype=np.uint8)
             sample = fo.Sample(filepath=image_path)
             sample["initial_mask"] = fo.Segmentation(mask=initial_mask_array)
 
             # Attach refined mask if present
             if refined_mask_path and Path(refined_mask_path).exists():
-                refined_mask_array = np.array(Image.open(refined_mask_path).convert("L"), dtype=np.uint8)
-                sample["refined_mask"] = fo.Segmentation(mask=refined_mask_array)
+                try:
+                    refined_mask_array = np.array(Image.open(refined_mask_path).convert("L"), dtype=np.uint8)
+                    sample["refined_mask"] = fo.Segmentation(mask=refined_mask_array)
+                except Exception as e:
+                    log.warning(f"Error loading refined mask for {refined_mask_path}: {e}")
 
-            # Determine which tag to show in UI
-            if use_final_tag and final_tag:
+            # Always display the final tag if it exists and is non-empty
+            display_tags = []
+            
+            if final_tag:
                 display_tags = [t.strip() for t in final_tag.split(",") if t.strip()]
-            else:
+            elif initial_tag:
                 display_tags = [t.strip() for t in initial_tag.split(",") if t.strip()]
 
             if display_tags:
                 sample.tags = display_tags
 
             samples.append(sample)
-        log.info(f"Loaded {len(samples)} samples from database.")
+        
+        log.info(f"Loaded {len(samples)} samples (DB + new files).")
         return samples
-    
-    
-    def _create_dataset(self, samples=None) -> fo.Dataset:
+
+
+    def _create_dataset(self, samples: List[fo.Sample]) -> fo.Dataset:
         """
         Creates a FiftyOne dataset from samples defined in the SQLite DB.
         If dataset with same name exists, it will be deleted (optionally you can skip this for persistence).
@@ -307,42 +309,19 @@ class FiftyOneMaskInspector:
             fo.Dataset: The newly created FiftyOne dataset.
         """
         log.info(f"Creating dataset: {self.dataset_name}")
-        
-        if self.dataset_name in fo.list_datasets():
-            log.info(f"Dataset '{self.dataset_name}' already exists. Load it.")
-            # fo.load_dataset(self.dataset_name)
-            fo.delete_dataset(self.dataset_name)
-            
+        try:
+            if self.dataset_name in fo.list_datasets():
+                log.info(f"Dataset '{self.dataset_name}' already exists. Load it.")
+                fo.load_dataset(self.dataset_name)
 
-        # Query the DB for all relevant rows
-        db_rows = get_images_for_review(db_path=self.db_path)
-        fo_samples = []
-        for row in db_rows:
-            image_id, image_path, mask_path, refined_mask_path, initial_tag, final_tag, tags, status, reviewer, timestamp = row
-            # Skip if image/mask is missing
-            if not Path(image_path).exists() or not Path(mask_path).exists():
-                log.warning(f"Image or mask not found for {image_id}. Skipping.")
-                continue
+            dataset = fo.Dataset(self.dataset_name)
+            dataset.add_samples(samples)
+            return dataset
+        except Exception as e:
+            log.error(f"Error creating/loading dataset {self.dataset_name}: {e}")
+            raise
 
-            # Load masks as arrays
-            initial_mask_array = np.array(Image.open(mask_path).convert("L"), dtype=np.uint8)
-            sample = fo.Sample(filepath=image_path)
-            sample["initial_mask"] = fo.Segmentation(mask=initial_mask_array)
-            # Attach refined mask if present
-            if refined_mask_path and Path(refined_mask_path).exists():
-                refined_mask_array = np.array(Image.open(refined_mask_path).convert("L"), dtype=np.uint8)
-                sample["refined_mask"] = fo.Segmentation(mask=refined_mask_array)
-            # Attach tags from DB
-            if tags:
-                sample.tags = [t.strip() for t in tags.split(",") if t.strip()]
-            fo_samples.append(sample)
-
-        dataset = fo.Dataset(self.dataset_name)
-        dataset.add_samples(fo_samples)
-        return dataset
-
-
-    def _get_voxel_dataset_map(self) -> dict:
+    def _get_voxel_dataset_map(self) -> Dict[str, str]:
         """
         Creates a dictionary of image_name -> user tags from self.dataset.
 
@@ -357,70 +336,82 @@ class FiftyOneMaskInspector:
             dataset_map[image_name] = tags_str
         return dataset_map
 
-    def _handle_db(self, tag_field="initial_tag", reviewer=''):
-        """
-        After tagging in FiftyOne, update initial_tag or final_tag in DB for each sample.
-
-        Args:
-            tag_field (str): Which DB field to update, 'initial_tag' or 'final_tag'
-            reviewer (str): Name or identifier of the reviewer (optional)
-        """
-        assert tag_field in ("initial_tag", "final_tag"), "tag_field must be 'initial_tag' or 'final_tag'"
-
-        for sample in self.dataset:
-            image_name = Path(sample.filepath).name
-            canonical_tags = self.normalize_tags(sample.tags)
-            update_tags_for_sample(
-                image_id=image_name,
-                user_tags=canonical_tags,
-                reviewer=reviewer,
-                db_path=self.db_path
-            )
-
-    def run_voxel_inspection(self, reviewer=''):
+    def run_voxel_inspection(self) -> None:
         """
         Runs the full inspection workflow:
         """
-        samples = self._load_samples()
+        log.info("Starting voxel inspection workflow.")
+        samples: List[fo.Sample] = self._load_samples()
         self.dataset: fo.Dataset = self._create_dataset(samples)
         self.session = fo.launch_app(self.dataset, port=self.port)
+        log.info("FiftyOne session started. Waiting for tagging to finish...")
 
         try:
-            print("\nTag your images, then close the FiftyOne app or press Ctrl+C here to save.")
             self.session.wait()
         except KeyboardInterrupt:
             print("\nSession manually interrupted by user.")
+        except Exception as e:
+            log.error(f"FiftyOne session error: {e}")
         finally:
-            self.session.refresh()
-            self.session.close()
-            self._update_sqlite_db_with_tags(reviewer=reviewer)
-            print("Session closed.")
+            try:
+                self.session.refresh()
+                self.session.close()
+                log.info("FiftyOne session ended. Saving tags to database.")
+            except Exception as e:
+                log.warning(f"Error closing FiftyOne session: {e}")
 
-        # Save the voxel inspection results
-        self._handle_db()
-        log.info(f"Tags saved to database: {self.voxel_inspection_results_db}")
+        self._update_sqlite_db_with_tags()
+        log.info("Voxel inspection workflow complete.")
+        
 
-    def _update_sqlite_db_with_tags(self, reviewer='', tag_field="initial_tag"):
+
+    def _update_sqlite_db_with_tags(self) -> None:
         """
         After the session, updates SQLite DB with tags for all samples in the dataset.
         """
+        timestamp = datetime.datetime.now().isoformat()
+        updates = []
         for sample in self.dataset:
             image_name = Path(sample.filepath).name
             canonical_tags = self.normalize_tags(sample.tags)
-            update_tags_for_sample(
-                image_id=image_name,
-                user_tags=canonical_tags,
-                reviewer=reviewer,
-                db_path=self.db_path
-            )
+            tags = set([t.lower() for t in canonical_tags if t])
+            
+            initial_tag = None
+            final_tag = None
+            status = None
+            reviewer = None
+            if "good" in tags:
+                final_tag = "good"
+                status = "reviewed"
+                reviewer = self.reviewer
+            elif tags:
+                initial_tag = ",".join(sorted(tags))
+                status = "pending"
+                reviewer = self.reviewer
+            else:
+                status = "unreviewed"
+                reviewer = None\
+                
+            if isinstance(tags, set):
+                tags = ",".join(sorted(tags))
+            updates.append((initial_tag, final_tag, tags, status, reviewer, timestamp, image_name))
+        self.db.bulk_update_tags(updates)
+        self.db.commit()
+
+    def __del__(self):
+        try:
+            self.db.close()
+        except Exception as e:
+            log.warning(f"Error on DB close: {e}")
 
 def main(cfg: DictConfig) -> None:
     """
     Entry point for launching the voxel inspection process.
-
-    Args:
-        cfg (DictConfig): A configuration object containing all necessary paths and parameters.
     """
-
-    inspector = FiftyOneMaskInspector(cfg)
-    inspector.run_voxel_inspection()
+    log.info("Mask inspection script started.")
+    try:
+        inspector = FiftyOneMaskInspector(cfg)
+        inspector.run_voxel_inspection()
+    except Exception as e:
+        log.error(f"Fatal error in main(): {e}")
+    log.info("Mask inspection script finished.")

--- a/src/mask_gen_utils/mask_inspect.py
+++ b/src/mask_gen_utils/mask_inspect.py
@@ -74,8 +74,8 @@ class FiftyOneMaskInspector:
 
         image_names = []
         for only_include_tag in self.inspect_cfg.only_include_tags:
-            # Ensure "voxel tags" column is treated as string and handle NaN values
-            matched = self.df[self.df["voxel tags"].fillna("").astype(str).str.contains(only_include_tag)]["image_name"]
+            # Ensure "initial_voxel_tag" column is treated as string and handle NaN values
+            matched = self.df[self.df["initial_voxel_tag"].fillna("").astype(str).str.contains(only_include_tag)]["image_name"]
             image_names.extend(matched)
 
         mask_paths = []

--- a/src/mask_gen_utils/mask_inspect.py
+++ b/src/mask_gen_utils/mask_inspect.py
@@ -27,7 +27,7 @@ class FiftyOneMaskInspector:
     """
     Manages image-mask datasets and interactive inspection using FiftyOne.
 
-    Responsibilities:
+    Functionality:
     - Load image-mask pairs from specified directories.
     - Create and manage FiftyOne datasets.
     - Launch FiftyOne UI for visual inspection and tagging.
@@ -42,10 +42,9 @@ class FiftyOneMaskInspector:
         Args:
             cfg (DictConfig): Configuration object with the required fields:
         """
-        # Initialize and validate all required paths from the configuration
+        # Initialize required paths from the configuration
         self.mask_gen_cutout_dir = Path(cfg.paths.mask_gen_cutout_dir)
         self.refined_masks_dir_source = Path(cfg.paths.refined_masks_dir)
-
         self.voxel_inspection_results_dir = Path(cfg.paths.voxel_inspection_results_dir)
         self.voxel_inspection_results_dir.mkdir(parents=True, exist_ok=True)
         self.voxel_inspection_results_db = Path(cfg.paths.voxel_inspection_results_db)
@@ -53,25 +52,17 @@ class FiftyOneMaskInspector:
         # Configuration parameters for FiftyOne Voxel
         self.port = cfg.mask_gen.inspect.port
         self.dataset_name = cfg.mask_gen.inspect.dataset_name
-        
         self.dataset = None
         self.session = None
 
         # pipeline mode
         self.mode = cfg.mode
-
         self.inspect_cfg = cfg.mask_gen.inspect
 
-    def get_mask_paths_from_src(self) -> list:
-        """
-        Retrieves image names and their corresponding mask tags from the initial mask inspection source directory.
+        # load db if exists or create a new one
+        self.df = pd.read_csv(self.voxel_inspection_results_db, index_col=False) if self.voxel_inspection_results_db.exists() else pd.DataFrame()
 
-        Returns:
-            list: A list of strings representing image names and their corresponding mask tags.
-        """
-        return sorted(self.mask_gen_cutout_dir.glob("*_mask.png"))
-
-    def get_mask_paths_from_db(self) -> list:
+    def _get_mask_paths_from_db(self) -> list:
         """
         Gets image names from the voxel inspection results database.
 
@@ -81,13 +72,10 @@ class FiftyOneMaskInspector:
         if not self.voxel_inspection_results_db.exists():
             return []
 
-        df = pd.read_csv(self.voxel_inspection_results_db)
-        
-
         image_names = []
         for only_include_tag in self.inspect_cfg.only_include_tags:
             # Ensure "voxel tags" column is treated as string and handle NaN values
-            matched = df[df["voxel tags"].fillna("").astype(str).str.contains(only_include_tag)]["image_name"]
+            matched = self.df[self.df["voxel tags"].fillna("").astype(str).str.contains(only_include_tag)]["image_name"]
             image_names.extend(matched)
 
         mask_paths = []
@@ -101,51 +89,83 @@ class FiftyOneMaskInspector:
         
         return mask_paths
 
-    def load_samples(self) -> list:
+    def _create_sample_with_masks(self, mask_path: Path):
+        """
+        Creates a FiftyOne sample with initial and refined masks (if available).
+
+        Args:
+            mask_path (Path): Path to the initial mask image.
+
+        Returns:
+            fo.Sample or None: The sample object or None if the mask is invalid.
+        """
+        image_name = mask_path.name.replace("_mask.png", ".jpg")
+        if not mask_path.exists():
+            log.warning(f"Warning: Initial mask not found for {image_name}. Skipping.")
+            return None
+
+        initial_mask_array = np.array(Image.open(mask_path).convert("L"), dtype=np.uint8)
+        image_path = self.mask_gen_cutout_dir / image_name
+        sample = fo.Sample(filepath=str(image_path))
+        sample["initial_mask"] = fo.Segmentation(mask=initial_mask_array)
+
+        if self.refined_masks_dir_source:
+            refined_mask_path = self.refined_masks_dir_source / f"{Path(image_name).stem}_mask.png"
+            if refined_mask_path.exists():
+                refined_mask_array = np.array(Image.open(refined_mask_path).convert("L"), dtype=np.uint8)
+                sample["refined_mask"] = fo.Segmentation(mask=refined_mask_array)
+            else:
+                log.warning(f"Note: Refined mask not found for {image_path.name}.")
+
+        return sample
+
+    def _load_samples(self) -> list:
         """
         Loads images and their corresponding masks into FiftyOne samples.
 
         Returns:
             list: A list of `fiftyone.core.sample.Sample` objects with attached segmentation masks:
-                  - "initial masks": from `_mask.png` files
-                  - "prediction": from refined_masks `.png` files, if available
         """
-        
         if self.inspect_cfg.only_include_tags and self.voxel_inspection_results_db.exists():
-            mask_paths = self.get_mask_paths_from_db()
+            mask_paths = self._get_mask_paths_from_db()
             if not mask_paths:
                 raise ValueError("No mask paths found in the database. 'only_include_tags' is activated. Please check the voxel inspection results database.")
         else:
-            mask_paths = self.get_mask_paths_from_src()
+            mask_paths = sorted(self.mask_gen_cutout_dir.glob("*_mask.png"))
         
             if not mask_paths:
                 raise ValueError("No mask paths found. Please check the source directories or database.")
 
         samples = []
-        for initial_mask_path in mask_paths:
-            image_name = initial_mask_path.name.replace("_mask.png", ".jpg")
-            if not initial_mask_path.exists():
-                log.warning(f"Warning: Initial mask not found for {image_name}. Skipping.")
-                continue
-
-            initial_mask_array = np.array(Image.open(initial_mask_path).convert("L"), dtype=np.uint8)
-            image_path = self.mask_gen_cutout_dir / image_name
-            sample = fo.Sample(filepath=str(image_path))
-            sample["initial_mask"] = fo.Segmentation(mask=initial_mask_array)
-
-            if self.refined_masks_dir_source:
-                refined_mask_path = self.refined_masks_dir_source / f"{Path(image_name).stem}_mask.png"
-                if refined_mask_path.exists():
-                    refined_mask_array = np.array(Image.open(refined_mask_path).convert("L"), dtype=np.uint8)
-                    sample["refined_mask"] = fo.Segmentation(mask=refined_mask_array)
-                else:
-                    log.warning(f"Note: Refined mask not found for {image_path.name}.")
-            samples.append(sample)
+        for mask_path in mask_paths:
+            sample = self._create_sample_with_masks(mask_path)
+            if sample:
+                samples.append(sample)
 
         log.info(f"Loaded {len(samples)} samples.")
         return samples
+    
+    def _create_tag_map_from_db(self) -> dict:
+        """
+        Creates a dictionary mapping image names to their tags from the voxel inspection results database.
 
-    def create_dataset(self, samples) -> fo.Dataset:
+        Returns:
+            dict: A dictionary where keys are image names and values are lists of tags.
+        """
+        tag_map = {}
+        for _, row in self.df.iterrows():
+            image_name = str(row["image_name"])
+            if pd.notna(row["final_voxel_tag"]):
+                tag = row["final_voxel_tag"]
+            elif pd.notna(row["initial_voxel_tag"]):
+                tag = str(row["initial_voxel_tag"])
+            else:
+                tag = ""
+            tags = [t.strip() for t in tag.split(",") if t.strip()]
+            tag_map[image_name] = tags
+        return tag_map
+    
+    def _create_dataset(self, samples) -> fo.Dataset:
         """
         Creates a FiftyOne dataset with the given samples.
 
@@ -164,75 +184,129 @@ class FiftyOneMaskInspector:
             fo.delete_dataset(self.dataset_name)
 
         # Load tags from CSV if available
-        tags_map = {}
+        tag_map = {}
         if self.voxel_inspection_results_db.exists():
-            df = pd.read_csv(self.voxel_inspection_results_db)
-            for _, row in df.iterrows():
-                image_name = str(row["image_name"])
-                tags_str = str(row["voxel tags"]) if pd.notna(row["voxel tags"]) else ""
-                tags = [t.strip() for t in tags_str.split(",") if t.strip()]
-                tags_map[image_name] = tags
-            log.info(f"Loaded tags for {len(tags_map)} images from {self.voxel_inspection_results_db}")
+            tag_map = self._create_tag_map_from_db()
+            log.info(f"Loaded tags for {len(tag_map)} images from {self.voxel_inspection_results_db}")
         else:
             log.info(f"No existing tags found in {self.voxel_inspection_results_db}. Starting fresh.")
 
         # Assign tags to samples
         for sample in samples:
             image_name = Path(sample.filepath).name
-            if image_name in tags_map:
-                sample.tags = tags_map[image_name]
+            if image_name in tag_map:
+                sample.tags = tag_map[image_name]
 
         dataset = fo.Dataset(self.dataset_name)
         dataset.add_samples(samples)
         return dataset
 
-    def save_tags_to_db(self, output_csv: Path) -> None:
+    def _load_existing_data(self) -> dict:
         """
-        Updates a CSV file with image filenames and their associated tags from self.dataset.
-        Only replaces tags if they have changed; otherwise, keeps the existing tags.
-        Appends new images if not already present.
+        Loads the existing CSV into self.df and returns a map of existing data.
+        
+        Returns:
+            dict: A dictionary mapping image names to their initial and final voxel tags.
+        """
+        existing_data = {}
+        for _, row in self.df.iterrows():
+            existing_data[row["image_name"]] = {
+                "initial_voxel_tag": row["initial_voxel_tag"],
+                "final_voxel_tag": row["final_voxel_tag"]
+            }
+        return existing_data
+
+    def _update_existing_rows(self, current_data: dict) -> None:
+        """
+        Updates self.df based on current_data if tags have changed.
+        
+        Args:
+            current_data (dict): A dictionary mapping image names to their new tags.
+        """
+        for idx, row in self.df.iterrows():
+            image_name = row["image_name"]
+            if image_name not in current_data:
+                continue
+
+            new_tags = current_data[image_name]
+            old_tags = str(row["initial_voxel_tag"]) if pd.notna(row["initial_voxel_tag"]) else ""
+
+            if old_tags == "good":
+                continue  # Do not change 'good'
+            elif new_tags == "good":
+                self.df.at[idx, "final_voxel_tag"] = new_tags
+            elif new_tags != old_tags and new_tags != "good":
+                self.df.at[idx, "initial_voxel_tag"] = new_tags
+
+    def _append_new_rows(self, current_data: dict, existing_data: dict) -> None:
+        """
+        Appends rows to self.df for any new image names not already present.
+
+        Args:
+            current_data (dict): A dictionary mapping image names to their tags.
+            existing_data (dict): A dictionary mapping existing image names to their tags.
+        """
+        new_rows = []
+        for image_name, tags_str in current_data.items():
+            if image_name not in existing_data:
+                new_rows.append({
+                    "image_name": image_name,
+                    "initial_voxel_tag": tags_str,
+                    "final_voxel_tag": ""
+                })
+        if new_rows:
+            self.df = pd.concat([self.df, pd.DataFrame(new_rows)], ignore_index=True)
+
+    def _create_new_dataframe(self, current_data: dict) -> None:
+        """
+        Creates a new DataFrame from scratch when no CSV exists.
+        Args:
+            current_data (dict): A dictionary mapping image names to their tags."""
+        self.df = pd.DataFrame([
+            {
+                "image_name": image_name,
+                "initial_voxel_tag": tags_str,
+                "final_voxel_tag": ""
+            }
+            for image_name, tags_str in current_data.items()
+        ])
+
+    def _get_current_dataset_map(self) -> dict:
+        """
+        Creates a dictionary of image_name -> tags from self.dataset.
+
+        Returns:
+            dict: A dictionary where keys are image filenames and values are comma-separated tag strings.
+        """
+        dataset_map = {}
+        for sample in self.dataset:
+            image_name = Path(sample.filepath).name
+            tags = sample.tags if sample.tags else []
+            tags_str = ",".join(tags)
+            dataset_map[image_name] = tags_str
+        return dataset_map
+
+    def _save_tags_to_db(self, output_csv: Path) -> None:
+        """
+        Writes updated tagging information from the FiftyOne session back to the voxel inspection CSV.
+
+        - Updates existing entries if tags have changed (except for 'good' which is preserved).
+        - Appends any new image entries not already in the CSV.
+
+        Args:
+            output_csv (Path): Destination path for the updated voxel inspection CSV.
         """
         output_csv = Path(output_csv)
-
-        # Create a dictionary from the current dataset
-        current_data = {
-            Path(sample.filepath).name: ",".join(sample.tags) if sample.tags else ""
-            for sample in self.dataset
-        }
+        current_data = self._get_current_dataset_map()
 
         if output_csv.exists():
-            # Load existing CSV
-            df = pd.read_csv(output_csv)
-
-            # Create a map from the current CSV
-            existing_data = dict(zip(df["image_name"], df["voxel tags"]))
-
-            # Update only if tags have changed
-            for idx, row in df.iterrows():
-                image_name = row["image_name"]
-                if image_name in current_data:
-                    new_tags = current_data[image_name]
-                    old_tags = str(row["voxel tags"]) if pd.notna(row["voxel tags"]) else ""
-                    if new_tags and new_tags != old_tags:
-                        df.at[idx, "voxel tags"] = new_tags
-                    # If new_tags is empty or unchanged, keep the old tags
-
-            # Append new rows (not in the original CSV)
-            for image_name, tags_str in current_data.items():
-                if image_name not in existing_data:
-                    df = pd.concat([df, pd.DataFrame([{
-                        "image_name": image_name,
-                        "voxel tags": tags_str
-                    }])], ignore_index=True)
+            existing_data = self._load_existing_data()
+            self._update_existing_rows(current_data)
+            self._append_new_rows(current_data, existing_data)
         else:
-            # Create new DataFrame if CSV doesn't exist
-            df = pd.DataFrame([
-                {"image_name": image_name, "voxel tags": tags_str}
-                for image_name, tags_str in current_data.items()
-            ])
+            self._create_new_dataframe(current_data)
 
-        # Save the updated DataFrame
-        df.to_csv(output_csv, index=False)
+        self.df.to_csv(output_csv, index=False)
 
     def run_voxel_inspection(self) -> None:
         """
@@ -243,9 +317,10 @@ class FiftyOneMaskInspector:
         - Launches the FiftyOne App for user-driven tagging.
         - Waits for the session to close (Ctrl+C).
         - Exports tags to a CSV in the results directory.
+        TODO: improve docstring for whole script
         """
-        samples = self.load_samples()
-        self.dataset: fo.Dataset = self.create_dataset(samples)
+        samples = self._load_samples()
+        self.dataset: fo.Dataset = self._create_dataset(samples)
         self.session = fo.launch_app(self.dataset, port=self.port)
 
         try:
@@ -267,7 +342,7 @@ class FiftyOneMaskInspector:
             print("Session closed.")
 
         # Save the voxel inspection results
-        self.save_tags_to_db(self.voxel_inspection_results_db)
+        self._save_tags_to_db(self.voxel_inspection_results_db)
         log.info(f"Tags saved to database: {self.voxel_inspection_results_db}")
 
 def main(cfg: DictConfig) -> None:

--- a/src/mask_gen_utils/mask_inspect.py
+++ b/src/mask_gen_utils/mask_inspect.py
@@ -16,22 +16,19 @@ Key Features:
 import os
 import fiftyone as fo
 from omegaconf import DictConfig
-from omegaconf import OmegaConf
 from PIL import Image
-import json
 import numpy as np
 from pathlib import Path
-import pandas as pd
 import logging
 import sqlite3
 import datetime
-from typing import List, Dict, Optional, Set, Tuple
+from typing import List, Dict, Set, Tuple
 
 # Logging configuration
 log = logging.getLogger(__name__)
 
 
-DB_PATH = "inspection.db" # TODO: pull from cfg.paths.db_path or similar
+TABLE_NAME = "mask_gen_images"
 
 class InspectionDB:
     def __init__(self, db_path: str) -> None:
@@ -46,8 +43,8 @@ class InspectionDB:
     def _init_db(self) -> None:
         c = self.conn.cursor()
         try:
-            c.execute('''
-            CREATE TABLE IF NOT EXISTS images (
+            c.execute(f'''
+            CREATE TABLE IF NOT EXISTS {TABLE_NAME} (
                 image_id TEXT PRIMARY KEY,
                 image_path TEXT,
                 mask_path TEXT,
@@ -69,8 +66,8 @@ class InspectionDB:
         log.info(f"Bulk-inserting {len(image_info_list)} new images into DB")
         c = self.conn.cursor()
         try:
-            c.executemany('''
-                INSERT OR IGNORE INTO images (
+            c.executemany(f'''
+                INSERT OR IGNORE INTO {TABLE_NAME} (
                     image_id, image_path, mask_path, refined_mask_path, 
                     initial_tag, final_tag, tags, status, reviewer, timestamp
                 ) VALUES (?, ?, ?, ?, '', '', '', 'pending', '', '')
@@ -82,8 +79,8 @@ class InspectionDB:
     def add_or_update_image(self, image_id: str, image_path: str, mask_path: str, refined_mask_path: str) -> None:
         c = self.conn.cursor()
         try:
-            c.execute('''
-                INSERT OR IGNORE INTO images (
+            c.execute(f'''
+                INSERT OR IGNORE INTO {TABLE_NAME} (
                     image_id, image_path, mask_path, refined_mask_path, 
                     initial_tag, final_tag, tags, status, reviewer, timestamp
                 )
@@ -105,7 +102,7 @@ class InspectionDB:
                     params.append(f"%{tag}%")
                 where_clauses.append("(" + " OR ".join(tag_clauses) + ")")
 
-            base_query = "SELECT * FROM images"
+            base_query = f"SELECT * FROM {TABLE_NAME}"
             if where_clauses:
                 base_query += " WHERE " + " AND ".join(where_clauses)
 
@@ -125,7 +122,7 @@ class InspectionDB:
         c = self.conn.cursor()
         try:
             c.executemany(
-                "UPDATE images SET initial_tag=?, final_tag=?, tags=?, status=?, reviewer=?, timestamp=? WHERE image_id=?",
+                f"UPDATE {TABLE_NAME} SET initial_tag=?, final_tag=?, tags=?, status=?, reviewer=?, timestamp=? WHERE image_id=?",
                 updates
             )
         except Exception as e:
@@ -135,7 +132,7 @@ class InspectionDB:
     def get_all_image_ids(self) -> Set[str]:
         c = self.conn.cursor()
         try:
-            c.execute("SELECT image_id FROM images")
+            c.execute(f"SELECT image_id FROM {TABLE_NAME}")
             return set(row[0] for row in c.fetchall())
         except Exception as e:
             log.error(f"Error fetching image IDs from DB: {e}")
@@ -145,9 +142,9 @@ class InspectionDB:
         # Only return those with a non-empty initial_tag and not already final_tag == "good"
         c = self.conn.cursor()
         try:
-            base_query = '''
+            base_query = f'''
                 SELECT *
-                FROM images
+                FROM {TABLE_NAME}
                 WHERE 
                     (final_tag IS NULL OR final_tag != "good")
                     AND (initial_tag IS NOT NULL AND TRIM(initial_tag) != "")
@@ -210,7 +207,7 @@ class FiftyOneMaskInspector:
         # Initialize required paths from the configuration
         self.mask_gen_cutout_dir = Path(cfg.paths.mask_gen_cutout_dir)
         self.refined_masks_dir = Path(cfg.paths.refined_masks_dir)
-        self.db_path = DB_PATH # TODO: pull from cfg.paths.db_path or similar
+        self.db_path = cfg.paths.agir_field_db
 
         # Use persistent DB connection
         self.db = InspectionDB(self.db_path)
@@ -444,6 +441,7 @@ def main(cfg: DictConfig) -> None:
     """
     Entry point for launching the voxel inspection process.
     """
+    # TODO: Move images marked as good to long-term storage or test directory.
     log.info("Mask inspection script started.")
     try:
         inspector = FiftyOneMaskInspector(cfg)

--- a/src/mask_gen_utils/mask_refine.py
+++ b/src/mask_gen_utils/mask_refine.py
@@ -3,12 +3,14 @@ import logging
 from pathlib import Path
 
 import cv2
+import json
 import hydra
 import numpy as np
 from omegaconf import DictConfig
+from omegaconf import OmegaConf
 from typing import Dict, Tuple, Any
 
-from src.mask_gen_utils.mask_inspect import InspectionDB, DB_PATH
+from src.mask_gen_utils.mask_inspect import InspectionDB
 from src.mask_gen_utils.missing_red  import MissingRed
 from src.mask_gen_utils.missing_white import MissingWhite
 from src.mask_gen_utils.present_mat import PresentMat
@@ -29,7 +31,7 @@ class RefineMask:
             "present_mat": (PresentMat(refine_cfg.present_mat), refine_cfg.present_mat),
         }
 
-        self.db_path = DB_PATH
+        self.db_path = cfg.paths.agir_field_db
         self.db = InspectionDB(self.db_path)
 
         self.timestamp = datetime.datetime.now().isoformat()
@@ -62,16 +64,16 @@ class RefineMask:
         log.info("Loading images needing refinement from database...")
         images = self.db.get_images_for_refinement(only_tags=self.only_tags)
         updates = []
-        for _, image_path, mask_path, _, initial_tag, final_tag, tags, _, _, _ in images:
+        for _, image_path, mask_path, _, initial_tag, final_tag, tags, _, _, _, _ in images:
             tag = initial_tag.split(",")[0].strip().lower()
             image_name = Path(image_path).name
-            refined_mask, _ = self._process_single_image(image_path, mask_path, tag)
+            refined_mask, refine_cfg = self._process_single_image(image_path, mask_path, tag)
             self._save_refined_mask(refined_mask, image_name)
             status = "refined"
             reviewer = "matt"
             timestamp = self.timestamp
-
-            updates.append((initial_tag, final_tag, tags, status, reviewer, timestamp, image_name))
+            refine_params_str = json.dumps(OmegaConf.to_container(refine_cfg, resolve=True))
+            updates.append((initial_tag, final_tag, tags, status, reviewer, timestamp, refine_params_str, image_name))
 
         self.db.bulk_update_tags(updates)
         self.db.commit()

--- a/src/mask_gen_utils/mask_refine.py
+++ b/src/mask_gen_utils/mask_refine.py
@@ -10,7 +10,7 @@ from omegaconf import DictConfig
 from omegaconf import OmegaConf
 from typing import Dict, Tuple, Any
 
-from src.mask_gen_utils.mask_inspect import InspectionDB
+from src.mask_gen_utils.db_utils import InspectionDB
 from src.mask_gen_utils.missing_red  import MissingRed
 from src.mask_gen_utils.missing_white import MissingWhite
 from src.mask_gen_utils.present_mat import PresentMat
@@ -32,7 +32,7 @@ class RefineMask:
         }
 
         self.db_path = cfg.paths.agir_field_db
-        self.db = InspectionDB(self.db_path)
+        self.db = InspectionDB(cfg)
 
         self.timestamp = datetime.datetime.now().isoformat()
 
@@ -53,7 +53,6 @@ class RefineMask:
         log.info(f"Processing tag: {tag}")
         refined_mask = processor.process(image, mask)
         return refined_mask, cfg
-
 
     def _save_refined_mask(self, mask: np.ndarray, image_name: str) -> None:
         output_path = self.refined_mask_dir / image_name.replace(".jpg", "_mask.png")

--- a/src/mask_gen_utils/mask_refine.py
+++ b/src/mask_gen_utils/mask_refine.py
@@ -53,14 +53,21 @@ class RefineMask:
         self.mask_refine_save_dir = self.mask_generation_dir / "refined_masks"
         self.mask_refine_save_dir.mkdir(parents=True, exist_ok=True)
         
+        # Path to the voxel inspection results CSV
         self.voxel_inspection_results_db_path = Path(cfg.paths.voxel_inspection_results_db)
-        self.df_voxel_db = self._load_voxel_db()
+        self.df_voxel_db = self._load_voxel_db() # Load the voxel inspection results into a DataFrame
 
+        # Canonical tag mapping from the configuration
         self.canonical_tag_mapping = cfg.mask_gen.canonical_tag_mapping
 
+        # Tags to remove from the final mask
         self.remove_tags = cfg.mask_gen.remove_tags if cfg.mask_gen.remove_tags else []
 
+        # Only include tags specified in the configuration if provided
         self.only_include_tags = cfg.mask_gen.refine.only_include_tags
+
+        # Load tags to filter the DataFrame
+        self.filter_db_by_final_voxel_tags = list(cfg.mask_gen.refine.filter_db_by_final_voxel_tags) if cfg.mask_gen.refine.filter_db_by_final_voxel_tags else []
 
         # refine parameters for missing red; HUE for red is split into two ranges to cover the full spectrum
         self.missing_red_cfg = cfg.mask_gen.refine.missing_red
@@ -84,7 +91,51 @@ class RefineMask:
         if not self.voxel_inspection_results_db_path.exists():
             raise FileNotFoundError(f"Voxel inspection results database (csv) not found at {self.voxel_inspection_results_db_path}")
         return pd.read_csv(self.voxel_inspection_results_db_path)
-                
+
+    def _get_df_needing_refinement(self) -> pd.DataFrame:
+        """
+        Returns a DataFrame of images that need mask refinement.
+
+        Returns:
+            pd.DataFrame: Filtered DataFrame containing only images that need refinement.
+        """
+        df_voxel_db_need_refining = self.df_voxel_db.copy()
+        for tag in self.filter_db_by_final_voxel_tags:
+            # Filter out images that have the tag to be filtered in their final_voxel_tag column
+            df_voxel_db_need_refining = df_voxel_db_need_refining[~df_voxel_db_need_refining["final_voxel_tag"].astype(str).str.contains(tag, na=False)]
+        return df_voxel_db_need_refining
+    
+    def _get_matching_voxel_tag_map(self, tag_keywords):
+        """
+        Creates a mapping of image names to their corresponding tags based on keywords.
+        Args:
+            tag_keywords (Dict[str, str]): Dictionary mapping tag labels to keywords.
+        Returns:
+            Dict[str, str]: Mapping of image names to their corresponding tags.
+        """
+        tag_map = {}
+        for tag_label, keyword in tag_keywords.items():
+            # filter the DataFrame for images that are not tagged "good"
+            df_voxel_db_need_refining = self._get_df_needing_refinement()
+            # Find all images that match the keyword in their initial_voxel_tag
+            matched = df_voxel_db_need_refining[df_voxel_db_need_refining["initial_voxel_tag"].astype(str).str.contains(keyword, na=False)]["image_name"]
+            tag_map.update({name: tag_label for name in matched})
+        return tag_map
+    
+    def _get_unmatched_voxel_tag_map(self, tag_keywords):
+        """
+        Finds images in the voxel inspection results that do not match any of the specified tag keywords.
+        Args:
+            tag_keywords (Dict[str, str]): Dictionary mapping tag labels to keywords.
+        Returns:
+            Dict[str, str]: Mapping of image names to their unmatched initial_voxel_tag.
+        """
+        # Create a regex pattern from the tag keywords
+        pattern = "|".join([re.escape(keyword) for keyword in tag_keywords.values()])
+        unmatched = self.df_voxel_db[~self.df_voxel_db["initial_voxel_tag"].str.contains(pattern, na=False, regex=True)]
+        unmatched_tag_map = dict(zip(unmatched["image_name"], unmatched["initial_voxel_tag"]))
+        return unmatched_tag_map
+
     def _map_voxel_tags(self) -> Dict[str, str]:
         """
         Maps voxel inspection tags to canonical tags defined in the configuration.
@@ -92,18 +143,10 @@ class RefineMask:
         tag_keywords = self.canonical_tag_mapping
 
         # Set the voxel tag to the correct canonical tag (the key in tag_keywords)
-        tag_map = {}
-        for tag_label, keyword in tag_keywords.items():
-            # filter the DataFrame for images that are not tagged "good"
-            df_voxel_db_need_refining = self.df_voxel_db[~self.df_voxel_db["final_voxel_tag"].astype(str).str.contains("good", na=False)]
-            # Find all images that match the keyword in their initial_voxel_tag
-            matched = df_voxel_db_need_refining[df_voxel_db_need_refining["initial_voxel_tag"].astype(str).str.contains(keyword, na=False)]["image_name"]
-            tag_map.update({name: tag_label for name in matched})
-
+        tag_map = self._get_matching_voxel_tag_map(tag_keywords)
         # Check for unmatched tags
-        pattern = "|".join([re.escape(keyword) for keyword in tag_keywords.values()])
-        unmatched = self.df_voxel_db[~self.df_voxel_db["initial_voxel_tag"].str.contains(pattern, na=False, regex=True)]
-        unmatched_tag_map = dict(zip(unmatched["image_name"], unmatched["initial_voxel_tag"]))
+        unmatched_tag_map = self._get_unmatched_voxel_tag_map(tag_keywords)
+
         if unmatched_tag_map:
             log.warning(f"Unmatched tags found in voxel inspection results: {unmatched_tag_map}")
 

--- a/src/mask_gen_utils/mask_refine.py
+++ b/src/mask_gen_utils/mask_refine.py
@@ -66,9 +66,6 @@ class RefineMask:
         # Only include tags specified in the configuration if provided
         self.only_include_tags = cfg.mask_gen.refine.only_include_tags
 
-        # Load tags to filter the DataFrame
-        self.filter_db_by_final_voxel_tags = list(cfg.mask_gen.refine.filter_db_by_final_voxel_tags) if cfg.mask_gen.refine.filter_db_by_final_voxel_tags else []
-
         # refine parameters for missing red; HUE for red is split into two ranges to cover the full spectrum
         self.missing_red_cfg = cfg.mask_gen.refine.missing_red
         self.missing_red_processor = MissingRed(self.missing_red_cfg)
@@ -92,61 +89,38 @@ class RefineMask:
             raise FileNotFoundError(f"Voxel inspection results database (csv) not found at {self.voxel_inspection_results_db_path}")
         return pd.read_csv(self.voxel_inspection_results_db_path)
 
-    def _get_df_needing_refinement(self) -> pd.DataFrame:
+    def _get_df_needing_refinement(self, cfg: DictConfig) -> pd.DataFrame:
         """
         Returns a DataFrame of images that need mask refinement.
 
         Returns:
             pd.DataFrame: Filtered DataFrame containing only images that need refinement.
         """
-        df_voxel_db_need_refining = self.df_voxel_db.copy()
-        for tag in self.filter_db_by_final_voxel_tags:
-            # Filter out images that have the tag to be filtered in their final_voxel_tag column
-            df_voxel_db_need_refining = df_voxel_db_need_refining[~df_voxel_db_need_refining["final_voxel_tag"].astype(str).str.contains(tag, na=False)]
-        return df_voxel_db_need_refining
-    
-    def _get_matching_voxel_tag_map(self, tag_keywords):
-        """
-        Creates a mapping of image names to their corresponding tags based on keywords.
-        Args:
-            tag_keywords (Dict[str, str]): Dictionary mapping tag labels to keywords.
-        Returns:
-            Dict[str, str]: Mapping of image names to their corresponding tags.
-        """
-        tag_map = {}
-        for tag_label, keyword in tag_keywords.items():
-            # filter the DataFrame for images that are not tagged "good"
-            df_voxel_db_need_refining = self._get_df_needing_refinement()
-            # Find all images that match the keyword in their initial_voxel_tag
-            matched = df_voxel_db_need_refining[df_voxel_db_need_refining["initial_voxel_tag"].astype(str).str.contains(keyword, na=False)]["image_name"]
-            tag_map.update({name: tag_label for name in matched})
-        return tag_map
-    
-    def _get_unmatched_voxel_tag_map(self, tag_keywords):
-        """
-        Finds images in the voxel inspection results that do not match any of the specified tag keywords.
-        Args:
-            tag_keywords (Dict[str, str]): Dictionary mapping tag labels to keywords.
-        Returns:
-            Dict[str, str]: Mapping of image names to their unmatched initial_voxel_tag.
-        """
-        # Create a regex pattern from the tag keywords
-        pattern = "|".join([re.escape(keyword) for keyword in tag_keywords.values()])
-        unmatched = self.df_voxel_db[~self.df_voxel_db["initial_voxel_tag"].str.contains(pattern, na=False, regex=True)]
-        unmatched_tag_map = dict(zip(unmatched["image_name"], unmatched["initial_voxel_tag"]))
-        return unmatched_tag_map
+        # Load tags from config to filter the DataFrame
+        tags_to_filter_db = list(cfg.mask_gen.refine.filter_db_by_final_voxel_tags)
 
-    def _map_voxel_tags(self) -> Dict[str, str]:
+        for tag in tags_to_filter_db:
+            # Filter out images that have the tag to be filtered in their final_voxel_tag column
+            df_voxel_db_need_refining = self.df_voxel_db[~self.df_voxel_db["final_voxel_tag"].astype(str).str.contains(tag, na=False)]
+        return df_voxel_db_need_refining
+
+    def _map_voxel_tags(self, df_voxel_db_need_refining: pd.DataFrame) -> Dict[str, str]:
         """
         Maps voxel inspection tags to canonical tags defined in the configuration.
         """
         tag_keywords = self.canonical_tag_mapping
 
         # Set the voxel tag to the correct canonical tag (the key in tag_keywords)
-        tag_map = self._get_matching_voxel_tag_map(tag_keywords)
-        # Check for unmatched tags
-        unmatched_tag_map = self._get_unmatched_voxel_tag_map(tag_keywords)
+        tag_map = {}
+        for tag_label, keyword in tag_keywords.items():
+            # Find all images that match the keyword in their initial_voxel_tag
+            matched = df_voxel_db_need_refining[df_voxel_db_need_refining["initial_voxel_tag"].astype(str).str.contains(keyword, na=False)]["image_name"]
+            tag_map.update({name: tag_label for name in matched})
 
+        # Check for unmatched tags
+        pattern = "|".join([re.escape(keyword) for keyword in tag_keywords.values()])
+        unmatched = df_voxel_db_need_refining[~df_voxel_db_need_refining["initial_voxel_tag"].astype(str).str.contains(pattern, na=False, regex=True)]
+        unmatched_tag_map = dict(zip(unmatched["image_name"], unmatched["initial_voxel_tag"]))
         if unmatched_tag_map:
             log.warning(f"Unmatched tags found in voxel inspection results: {unmatched_tag_map}")
 
@@ -154,7 +128,7 @@ class RefineMask:
             raise ValueError("No tags found in voxel inspection results. Ensure the CSV is populated correctly.")
         
         return tag_map
-
+    
     def _update_voxel_tags_to_canonical(self, tag_map: Dict[str, str]) -> None:
         """
         Updates the DataFrame to use canonical tags for each image in tag_map.
@@ -279,20 +253,26 @@ class RefineMask:
         """
         self.df_voxel_db.to_csv(self.voxel_inspection_results_db_path, index=False)
         log.info(f"Voxel inspection results database updated and saved to {self.voxel_inspection_results_db_path}")
-        
-    def process_cutout_dir(self) -> None:
+
+    def process_cutout_dir(self, cfg: DictConfig) -> None:
         """
         Processes cropout images and refines masks based on voxel inspection tags.
         """
         try:
             ## Handling tags and already refined masks
             # TODO: improve this by catching and handling tag discrepancies, "other" tags, "bad" tags, etc.
+            # Get the DataFrame of images that need refinement
+            df_voxel_db_need_refining = self._get_df_needing_refinement(cfg)
+
             # Load and map voxel inspection tags to canonical tags
-            tag_map = self._map_voxel_tags()
+            tag_map = self._map_voxel_tags(df_voxel_db_need_refining)
+
             # Update the voxel inspection results DataFrame with canonical tags
             self._update_voxel_tags_to_canonical(tag_map)
+
             # Remove refined masks for tags that should not be processed
             cleaned_tag_map = self._remove_refined_masks(tag_map)
+
             # Remove entries from the voxel inspection results DB for tags that should not be processed
             self._update_db_with_remove_tags(cleaned_tag_map)
 
@@ -335,5 +315,5 @@ def main(cfg: DictConfig) -> None:
     TODO: make tags handling more robust, e.g., handle "other" tags, "bad" tags, tag discrepencies, etc.
     """
     refine_mask = RefineMask(cfg)
-    refine_mask.process_cutout_dir()
+    refine_mask.process_cutout_dir(cfg)
     log.info("Refining mask process completed successfully.")

--- a/src/mask_gen_utils/mask_refine.py
+++ b/src/mask_gen_utils/mask_refine.py
@@ -1,322 +1,87 @@
-"""
-Mask Refinement Module
-
-Refines binary segmentation masks for plant images based on tags from a voxel inspection CSV.
-
-Functionality:
-- Identifies mask issues using tags: "missing_red", "missing_white", "present_mat", "bad", and "other".
-- Applies HSV thresholding and morphological operations to fix missing regions or remove background mats.
-- Updates the voxel inspection CSV with applied parameters.
-- Saves refined masks to an output directory for downstream use.
-"""
-import os
-import cv2
+import datetime
 import logging
-import numpy as np
 from pathlib import Path
-from omegaconf import DictConfig, ListConfig
-import pandas as pd
+
+import cv2
+import hydra
+import numpy as np
+from omegaconf import DictConfig
 from typing import Dict, Tuple, Any
 
+from src.mask_gen_utils.mask_inspect import InspectionDB, DB_PATH
 from src.mask_gen_utils.missing_red  import MissingRed
 from src.mask_gen_utils.missing_white import MissingWhite
 from src.mask_gen_utils.present_mat import PresentMat
-import re
 
-# Logging configuration
 log = logging.getLogger(__name__)
 
-
 class RefineMask:
-    """
-    Refines segmentation masks based on voxel-inspection tags using HSV filtering and 
-    morphological operations.
-
-    Supported tags and operations:
-    - "missing_red": Detects red regions using HSV and adds to mask.
-    - "missing_white": Detects white regions using HSV and adds to mask.
-    - "present_mat": Detects background mat presence and removes it from mask.
-    - "bad": if present, removes the refined masks so initial mask is used in next steps.
-    - "other": skips processing for images with other tags.
-    """
     def __init__(self, cfg: DictConfig) -> None:
-        """
-        Initializes the RefineMask processor with configuration parameters.
-
-        Args:
-            cfg (DictConfig): Hydra configuration object containing paths and HSV/morph settings.
-        """
-        # Setup directories
         self.mask_generation_dir = Path(cfg.paths.project_maskgen_dir)
-        self.developed_images_dir = self.mask_generation_dir / "developed-images"
         self.cutout_dir = self.mask_generation_dir / "cutouts"
-        self.mask_refine_save_dir = self.mask_generation_dir / "refined_masks"
-        self.mask_refine_save_dir.mkdir(parents=True, exist_ok=True)
-        
-        # Path to the voxel inspection results CSV
-        self.voxel_inspection_results_db_path = Path(cfg.paths.voxel_inspection_results_db)
-        self.df_voxel_db = self._load_voxel_db() # Load the voxel inspection results into a DataFrame
+        self.refined_mask_dir = self.mask_generation_dir / "refined_masks"
+        self.refined_mask_dir.mkdir(parents=True, exist_ok=True)
 
-        # Canonical tag mapping from the configuration
-        self.canonical_tag_mapping = cfg.mask_gen.canonical_tag_mapping
+        refine_cfg = cfg.mask_gen.refine
+        self.processors = {
+            "missing_red": (MissingRed(refine_cfg.missing_red), refine_cfg.missing_red),
+            "missing_white": (MissingWhite(refine_cfg.missing_white), refine_cfg.missing_white),
+            "present_mat": (PresentMat(refine_cfg.present_mat), refine_cfg.present_mat),
+        }
 
-        # Tags to remove from the final mask
-        self.remove_tags = cfg.mask_gen.remove_tags if cfg.mask_gen.remove_tags else []
+        self.db_path = DB_PATH
+        self.db = InspectionDB(self.db_path)
 
-        # Only include tags specified in the configuration if provided
-        self.only_include_tags = cfg.mask_gen.refine.only_include_tags
+        self.timestamp = datetime.datetime.now().isoformat()
 
-        # Load tags to filter the DataFrame
-        self.filter_db_by_final_voxel_tags = list(cfg.mask_gen.refine.filter_db_by_final_voxel_tags) if cfg.mask_gen.refine.filter_db_by_final_voxel_tags else []
+        self.only_tags = cfg.mask_gen.refine.only_tags
 
-        # refine parameters for missing red; HUE for red is split into two ranges to cover the full spectrum
-        self.missing_red_cfg = cfg.mask_gen.refine.missing_red
-        self.missing_red_processor = MissingRed(self.missing_red_cfg)
+    def _process_single_image(self, image_path: str, mask_path: str, tag: str) -> Tuple[np.ndarray, Dict[str, Any]]:
+        log.info(f"Refining mask for: {Path(image_path).name}")
 
-        # refine parameters for missing white
-        self.missing_white_cfg = cfg.mask_gen.refine.missing_white
-        self.missing_white_processor = MissingWhite(self.missing_white_cfg)
+        image = cv2.cvtColor(cv2.imread(image_path), cv2.COLOR_BGR2RGB)
+        mask = cv2.imread(mask_path, cv2.IMREAD_GRAYSCALE)
 
-        # refine parameters for present mat
-        self.present_mat_cfg = cfg.mask_gen.refine.present_mat
-        self.present_mat_processor = PresentMat(cfg.mask_gen.refine.present_mat)
-    
-    def _load_voxel_db(self) -> pd.DataFrame:
-        """
-        Loads the voxel inspection results CSV into a DataFrame.
-
-        Returns:
-            pd.DataFrame: DataFrame containing voxel inspection results.
-        """
-        if not self.voxel_inspection_results_db_path.exists():
-            raise FileNotFoundError(f"Voxel inspection results database (csv) not found at {self.voxel_inspection_results_db_path}")
-        return pd.read_csv(self.voxel_inspection_results_db_path)
-
-    def _get_df_needing_refinement(self, cfg: DictConfig) -> pd.DataFrame:
-        """
-        Returns a DataFrame of images that need mask refinement.
-
-        Returns:
-            pd.DataFrame: Filtered DataFrame containing only images that need refinement.
-        """
-        # Load tags from config to filter the DataFrame
-        tags_to_filter_db = list(cfg.mask_gen.refine.filter_db_by_final_voxel_tags)
-
-        for tag in tags_to_filter_db:
-            # Filter out images that have the tag to be filtered in their final_voxel_tag column
-            df_voxel_db_need_refining = self.df_voxel_db[~self.df_voxel_db["final_voxel_tag"].astype(str).str.contains(tag, na=False)]
-        return df_voxel_db_need_refining
-
-    def _map_voxel_tags(self, df_voxel_db_need_refining: pd.DataFrame) -> Dict[str, str]:
-        """
-        Maps voxel inspection tags to canonical tags defined in the configuration.
-        """
-        tag_keywords = self.canonical_tag_mapping
-
-        # Set the voxel tag to the correct canonical tag (the key in tag_keywords)
-        tag_map = {}
-        for tag_label, keyword in tag_keywords.items():
-            # Find all images that match the keyword in their initial_voxel_tag
-            matched = df_voxel_db_need_refining[df_voxel_db_need_refining["initial_voxel_tag"].astype(str).str.contains(keyword, na=False)]["image_name"]
-            tag_map.update({name: tag_label for name in matched})
-
-        # Check for unmatched tags
-        pattern = "|".join([re.escape(keyword) for keyword in tag_keywords.values()])
-        unmatched = df_voxel_db_need_refining[~df_voxel_db_need_refining["initial_voxel_tag"].astype(str).str.contains(pattern, na=False, regex=True)]
-        unmatched_tag_map = dict(zip(unmatched["image_name"], unmatched["initial_voxel_tag"]))
-        if unmatched_tag_map:
-            log.warning(f"Unmatched tags found in voxel inspection results: {unmatched_tag_map}")
-
-        if not tag_map:
-            raise ValueError("No tags found in voxel inspection results. Ensure the CSV is populated correctly.")
-        
-        return tag_map
-    
-    def _update_voxel_tags_to_canonical(self, tag_map: Dict[str, str]) -> None:
-        """
-        Updates the DataFrame to use canonical tags for each image in tag_map.
-        """
-        for image_name, canonical_tag in tag_map.items():
-            idx = self.df_voxel_db[self.df_voxel_db["image_name"] == image_name].index
-            if not idx.empty:
-                self.df_voxel_db.loc[idx, "initial_voxel_tag"] = canonical_tag
-
-    def _remove_refined_masks(self, voxel_tag_map: Dict[str, str]) -> Dict[str, str]:
-        """
-        Removes refined masks for images with tags that are in the remove_tags list.
-        """
-        copy_of_voxel_tag_map = voxel_tag_map.copy()
-        for image_name, canonical_tag in copy_of_voxel_tag_map.items():
-
-            if canonical_tag in self.remove_tags:
-                refined_mask_path = self.mask_refine_save_dir / f"{image_name}_mask.png"
-                if refined_mask_path.exists():
-                    # Remove the refined mask if it exists
-                    os.remove(refined_mask_path)
-                    log.info(f"Removed mask for tag '{canonical_tag}': {refined_mask_path}")
-
-                else:
-                    log.warning(f"Refined mask not found for {image_name} with tag '{canonical_tag}'. No action taken.")
-
-        return voxel_tag_map
-
-    def _process_single_image(self, image_name: str, tag: str) -> Tuple[np.ndarray, Dict[str, Any]]:
-        """
-        Processes a single image-mask pair based on the associated tag.
-
-        Args:
-            image_name (str): str of the image file name (e.g., "image.jpg").
-            tag (str): Issue type tag ("missing_red", "missing_white", "present_mat", "bad", or "other").
-        """
-        log.info(f"Refining mask for: {image_name}")
-        
-        # Get the cropout image and initial mask paths
-        cropout_image_path = self.cutout_dir / Path(image_name)
-        initial_mask_path = self.cutout_dir / str(image_name).replace(".jpg", "_mask.png")
-
-        # Load the cropout image and initial mask
-        cropout_image = cv2.cvtColor(cv2.imread(str(cropout_image_path)), cv2.COLOR_BGR2RGB)
-        cropout_initial_mask = cv2.imread(str(initial_mask_path), cv2.IMREAD_GRAYSCALE)
-    
-        if tag == "missing_red":
-            log.info("Processing missing red regions.")
-            hsv_morph_parameters = self.missing_red_cfg
-            refined_mask = self.missing_red_processor.process_missing_red(
-                cropout_image, 
-                cropout_initial_mask
-            )
-            
-        elif tag == "missing_white":
-            log.info("Processing missing white regions.")
-            hsv_morph_parameters = self.missing_white_cfg
-            refined_mask = self.missing_white_processor.process_missing_white(
-                cropout_image, 
-                cropout_initial_mask
-            )
-        
-        elif tag == "present_mat":
-            log.info("Processing present mat regions.")
-            hsv_morph_parameters = self.present_mat_cfg
-            refined_mask = self.present_mat_processor.process_present_mat(
-                cropout_image, 
-                cropout_initial_mask
-            )
-            
-        # Sanity check
-        else:
-            log.error(f"Unknown tag '{tag}' for image {cropout_image_path}. Skipping refinement.")
+        processor_info = self.processors.get(tag)
+        if processor_info is None:
+            log.error(f"Unknown tag '{tag}' for image {Path(image_path).name}. Skipping.")
             return None, None
-        
-        return refined_mask, hsv_morph_parameters
-    
-    def _update_db_with_hsv_parameters(self, image_name: str, hsv_morph_param: Dict[str, Any]) -> None:
-        """
-        Updates the voxel inspection CSV with the HSV parameters used for mask refinement.
-        """
 
-        # Find the row corresponding to the image
-        row_idx = self.df_voxel_db[self.df_voxel_db["image_name"] == image_name].index
-    
-        for key, value in hsv_morph_param.items():            
-            if isinstance(value, (list, np.ndarray, ListConfig)):
-                value = ','.join(map(str, list(value)))
-            self.df_voxel_db.loc[row_idx[0], key] = value
+        processor, cfg = processor_info
+        log.info(f"Processing tag: {tag}")
+        refined_mask = processor.process(image, mask)
+        return refined_mask, cfg
 
-        log.info(f"Updated voxel inspection row for {image_name} with HSV parameters: {hsv_morph_param}")
 
-    
-    def _update_db_with_remove_tags(self, tags: Dict[str,str]) -> None:
-        """
-        Removes entries from the voxel inspection results DataFrame based on specified tags.
-        Args:
-            tags (Dict[str, str]): Dictionary mapping image names to their canonical tags.
-        """
-        for image_name, canonical_tag in tags.items():
-            if canonical_tag in self.remove_tags:
-                log.info(f"Removing {image_name} from voxel inspection results due to tag '{canonical_tag}'.")
-                row_idx = self.df_voxel_db[self.df_voxel_db["image_name"] == image_name].index
-                self.df_voxel_db.drop(row_idx, inplace=True)
-    
-    def _save_refined_mask(self, refined_mask: np.ndarray, image_name: str) -> None:
-        """
-        Saves the refined mask to the specified output path.
+    def _save_refined_mask(self, mask: np.ndarray, image_name: str) -> None:
+        output_path = self.refined_mask_dir / image_name.replace(".jpg", "_mask.png")
+        cv2.imwrite(str(output_path), mask)
+        log.info(f"Saved refined mask: {output_path}")
 
-        Args:
-            refined_mask (np.ndarray): The refined binary mask to save.
-            output_path (Path): The path where the mask will be saved.
-        """
-        mask_output_path = Path(self.mask_refine_save_dir) / str(image_name).replace(".jpg", "_mask.png")
-        
-        cv2.imwrite(str(mask_output_path), refined_mask)
-        log.info(f"Refined mask saved to: {mask_output_path}")
+    def process_cutout_dir(self) -> None:
+        log.info("Loading images needing refinement from database...")
+        images = self.db.get_images_for_refinement(only_tags=self.only_tags)
+        updates = []
+        for _, image_path, mask_path, _, initial_tag, final_tag, tags, _, _, _ in images:
+            tag = initial_tag.split(",")[0].strip().lower()
+            image_name = Path(image_path).name
+            refined_mask, _ = self._process_single_image(image_path, mask_path, tag)
+            self._save_refined_mask(refined_mask, image_name)
+            status = "refined"
+            reviewer = "matt"
+            timestamp = self.timestamp
 
-    def _save_df_voxel_db(self) -> None:
-        """
-        Saves the updated voxel inspection DataFrame to the CSV file.
-        """
-        self.df_voxel_db.to_csv(self.voxel_inspection_results_db_path, index=False)
-        log.info(f"Voxel inspection results database updated and saved to {self.voxel_inspection_results_db_path}")
+            updates.append((initial_tag, final_tag, tags, status, reviewer, timestamp, image_name))
 
-    def process_cutout_dir(self, cfg: DictConfig) -> None:
-        """
-        Processes cropout images and refines masks based on voxel inspection tags.
-        """
-        try:
-            ## Handling tags and already refined masks
-            # TODO: improve this by catching and handling tag discrepancies, "other" tags, "bad" tags, etc.
-            # Get the DataFrame of images that need refinement
-            df_voxel_db_need_refining = self._get_df_needing_refinement(cfg)
+        self.db.bulk_update_tags(updates)
+        self.db.commit()
+        log.info("All images processed and updated in the database.")
 
-            # Load and map voxel inspection tags to canonical tags
-            tag_map = self._map_voxel_tags(df_voxel_db_need_refining)
-
-            # Update the voxel inspection results DataFrame with canonical tags
-            self._update_voxel_tags_to_canonical(tag_map)
-
-            # Remove refined masks for tags that should not be processed
-            cleaned_tag_map = self._remove_refined_masks(tag_map)
-
-            # Remove entries from the voxel inspection results DB for tags that should not be processed
-            self._update_db_with_remove_tags(cleaned_tag_map)
-
-            for image_name, tag in cleaned_tag_map.items():
-                if self.only_include_tags and tag not in self.only_include_tags:
-                    log.info(f"Skipping {image_name} with tag '{tag}' as it is not in the only_include_tags list.")
-                    continue
-                try:
-                    # Process each image based on its tag
-                    refined_mask, hsv_morph_param = self._process_single_image(image_name, tag)
-                    if refined_mask is not None and hsv_morph_param is not None:
-                        # Save the refined mask and update the voxel inspection results DB
-                        self._update_db_with_hsv_parameters(image_name, hsv_morph_param)
-                        self._save_refined_mask(refined_mask, image_name)
-                        log.info(f"Refining completed for: {image_name}")
-                    else:
-                        log.warning(f"Refinement skipped for {image_name} due to processing error or unsupported tag.")
-                
-                except Exception as e:
-                    log.error(f"Error processing {image_name}: {e}", exc_info=True)
-        
-        except Exception as main_e:
-            log.error(f"Fatal error during batch mask refinement: {main_e}", exc_info=True)
-        
-        finally:
-            # Always try to save the DB, even if something failed
-            self._save_df_voxel_db()
-
+@hydra.main(config_path="conf", config_name="config", version_base=None)
 def main(cfg: DictConfig) -> None:
-    """
-    Entry point for running the mask refinement process using configured HSV and morphological parameters.
-
-    Args:
-        cfg (DictConfig): Hydra configuration object with required settings.
-
-    Processes cropout images and refines masks based on voxel inspection tags.
-    TODO: improve this docstring
-    TODO: add error handling for missing data, processing errors, etc.
-    TODO: do something with masks with "bad", "other" tags (process again, create generic mask, etc.)
-    TODO: make tags handling more robust, e.g., handle "other" tags, "bad" tags, tag discrepencies, etc.
-    """
     refine_mask = RefineMask(cfg)
-    refine_mask.process_cutout_dir(cfg)
+    refine_mask.process_cutout_dir()
     log.info("Refining mask process completed successfully.")
+
+if __name__ == "__main__":
+    main()

--- a/src/mask_gen_utils/mask_refine.py
+++ b/src/mask_gen_utils/mask_refine.py
@@ -58,7 +58,7 @@ class RefineMask:
 
         self.canonical_tag_mapping = cfg.mask_gen.canonical_tag_mapping
 
-        self.remove_tags = cfg.mask_gen.remove_tags
+        self.remove_tags = cfg.mask_gen.remove_tags if cfg.mask_gen.remove_tags else []
 
         self.only_include_tags = cfg.mask_gen.refine.only_include_tags
 

--- a/src/mask_gen_utils/mask_refine.py
+++ b/src/mask_gen_utils/mask_refine.py
@@ -94,13 +94,16 @@ class RefineMask:
         # Set the voxel tag to the correct canonical tag (the key in tag_keywords)
         tag_map = {}
         for tag_label, keyword in tag_keywords.items():
-            matched = self.df_voxel_db[self.df_voxel_db["voxel tags"].str.contains(keyword, na=False)]["image_name"]
+            # filter the DataFrame for images that are not tagged "good"
+            df_voxel_db_need_refining = self.df_voxel_db[~self.df_voxel_db["final_voxel_tag"].astype(str).str.contains("good", na=False)]
+            # Find all images that match the keyword in their initial_voxel_tag
+            matched = df_voxel_db_need_refining[df_voxel_db_need_refining["initial_voxel_tag"].astype(str).str.contains(keyword, na=False)]["image_name"]
             tag_map.update({name: tag_label for name in matched})
-        
+
         # Check for unmatched tags
         pattern = "|".join([re.escape(keyword) for keyword in tag_keywords.values()])
-        unmatched = self.df_voxel_db[~self.df_voxel_db["voxel tags"].str.contains(pattern, na=False, regex=True)]
-        unmatched_tag_map = dict(zip(unmatched["image_name"], unmatched["voxel tags"]))
+        unmatched = self.df_voxel_db[~self.df_voxel_db["initial_voxel_tag"].str.contains(pattern, na=False, regex=True)]
+        unmatched_tag_map = dict(zip(unmatched["image_name"], unmatched["initial_voxel_tag"]))
         if unmatched_tag_map:
             log.warning(f"Unmatched tags found in voxel inspection results: {unmatched_tag_map}")
 
@@ -116,7 +119,7 @@ class RefineMask:
         for image_name, canonical_tag in tag_map.items():
             idx = self.df_voxel_db[self.df_voxel_db["image_name"] == image_name].index
             if not idx.empty:
-                self.df_voxel_db.loc[idx, "voxel tags"] = canonical_tag
+                self.df_voxel_db.loc[idx, "initial_voxel_tag"] = canonical_tag
 
     def _remove_refined_masks(self, voxel_tag_map: Dict[str, str]) -> Dict[str, str]:
         """

--- a/src/mask_gen_utils/missing_red.py
+++ b/src/mask_gen_utils/missing_red.py
@@ -9,38 +9,53 @@ class MissingRed:
     """
     
     def __init__(self, missing_red_cfg: DictConfig):
-        self.red_missing_hsv_lower = np.array(missing_red_cfg.hsv_lower, dtype=np.uint8)
-        self.red_missing_hsv_upper = np.array(missing_red_cfg.hsv_upper, dtype=np.uint8)
-        self.red_missing_hsv_lower_2 = np.array(missing_red_cfg.hsv_lower_2, dtype=np.uint8)
-        self.red_missing_hsv_upper_2 = np.array(missing_red_cfg.hsv_upper_2, dtype=np.uint8)
+        self.exr_thresh = missing_red_cfg.exr_thresh  # default if not set
+        self.saturation_thresh = missing_red_cfg.saturation_thresh  # default to 0 to always boost, but can be >0    
         self.red_opening_size = missing_red_cfg.opening_kernel_size
         self.red_closing_size = missing_red_cfg.closing_kernel_size
         self.red_erosion_size = missing_red_cfg.erosion_kernel_size
 
     def process_missing_red(self, image: np.ndarray, cropout_mask: np.ndarray) -> np.ndarray:
         """
-        Generate a binary mask for detecting red-colored regions using HSV thresholding.
+        Generate a binary mask for detecting red-colored regions using Excess Red (ExR) boosted by saturation.
 
         Args:
-            image (np.ndarray): RGB image.
+            image (np.ndarray): RGB image (OpenCV format).
+            cropout_mask (np.ndarray): Pre-existing mask to combine.
 
         Returns:
             np.ndarray: Binary mask with red-missing regions as 255.
         """
-        hsv_image = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
-        
-        refined_mask_for_red_1 = cv2.inRange(hsv_image, self.red_missing_hsv_lower, self.red_missing_hsv_upper)
-        refined_mask_for_red_2 = cv2.inRange(hsv_image, self.red_missing_hsv_lower_2, self.red_missing_hsv_upper_2)
-        refined_mask_red_final = cv2.bitwise_or(refined_mask_for_red_1, refined_mask_for_red_2)
-        
-        morphcleaned_refined_mask_red_final = MorphCleanedMask.morph_cleaned_mask(
-            refined_mask_red_final, 
-            self.red_opening_size, 
-            self.red_closing_size, 
+        # Calculate ExR
+        R = image[:, :, 0].astype(np.float32)
+        G = image[:, :, 1].astype(np.float32)
+        B = image[:, :, 2].astype(np.float32)
+        exr = 2 * R - G - B
+
+        # Calculate normalized saturation and mask out very gray pixels if desired
+        hsv = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
+        s = hsv[...,1].astype(np.float32)
+        s_norm = s / 255.0
+        if self.saturation_thresh > 0:
+            color_mask = (s >= self.saturation_thresh).astype(np.float32)
+            s_norm = s_norm * color_mask  # Optional: set normalized S to zero if below threshold
+
+        # Boost ExR by normalized saturation
+        exr_boosted = exr * s_norm
+
+        # Threshold ExR (boosted)
+        exr_mask = np.where(exr_boosted > self.exr_thresh, 255, 0).astype(np.uint8)
+
+        # Morphological cleaning
+        morphcleaned_exr_mask = MorphCleanedMask.morph_cleaned_mask(
+            exr_mask,
+            self.red_opening_size,
+            self.red_closing_size,
             self.red_erosion_size
-            )
-        
-        combined_refined_mask = cv2.bitwise_or(cropout_mask, morphcleaned_refined_mask_red_final)
+        )
+
+        # Combine with cropout_mask
+        combined_refined_mask = cv2.bitwise_or(cropout_mask, morphcleaned_exr_mask)
         combined_refined_mask_binary = np.where(combined_refined_mask > 0, 255, 0).astype(np.uint8)
 
         return combined_refined_mask_binary

--- a/src/mask_gen_utils/missing_red.py
+++ b/src/mask_gen_utils/missing_red.py
@@ -15,7 +15,7 @@ class MissingRed:
         self.red_closing_size = missing_red_cfg.closing_kernel_size
         self.red_erosion_size = missing_red_cfg.erosion_kernel_size
 
-    def process_missing_red(self, image: np.ndarray, cropout_mask: np.ndarray) -> np.ndarray:
+    def process(self, image: np.ndarray, cropout_mask: np.ndarray) -> np.ndarray:
         """
         Generate a binary mask for detecting red-colored regions using Excess Red (ExR) boosted by saturation.
 
@@ -56,6 +56,5 @@ class MissingRed:
 
         # Combine with cropout_mask
         combined_refined_mask = cv2.bitwise_or(cropout_mask, morphcleaned_exr_mask)
-        combined_refined_mask_binary = np.where(combined_refined_mask > 0, 255, 0).astype(np.uint8)
 
-        return combined_refined_mask_binary
+        return combined_refined_mask

--- a/src/mask_gen_utils/missing_red.py
+++ b/src/mask_gen_utils/missing_red.py
@@ -33,7 +33,7 @@ class MissingRed:
         exr = 2 * R - G - B
 
         # Calculate normalized saturation and mask out very gray pixels if desired
-        hsv = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
+        hsv = cv2.cvtColor(image, cv2.COLOR_RGB2HSV)
         s = hsv[...,1].astype(np.float32)
         s_norm = s / 255.0
         if self.saturation_thresh > 0:

--- a/src/mask_gen_utils/missing_white.py
+++ b/src/mask_gen_utils/missing_white.py
@@ -13,7 +13,7 @@ class MissingWhite:
     """
     Class for refining binary masks to detect missing white regions in images.
     """
-    def process_missing_white(self, image: np.ndarray, cropout_mask: np.ndarray) -> np.ndarray:
+    def process(self, image: np.ndarray, cropout_mask: np.ndarray) -> np.ndarray:
         """
         Generate a binary mask for detecting white-colored regions using HSV thresholding.
 
@@ -35,6 +35,5 @@ class MissingWhite:
             ) 
         
         combined_refined_mask = cv2.bitwise_or(cropout_mask, morphcleaned_refined_white_mask) # Combine the original mask with the refined mask
-        combined_refined_mask_binary = np.where(combined_refined_mask > 0, 255, 0).astype(np.uint8) # Convert to binary mask
-        
-        return combined_refined_mask_binary
+
+        return combined_refined_mask

--- a/src/mask_gen_utils/present_mat.py
+++ b/src/mask_gen_utils/present_mat.py
@@ -14,7 +14,7 @@ class PresentMat:
         self.mat_closing_size = present_mat_cfg.closing_kernel_size
         self.mat_erosion_size = present_mat_cfg.erosion_kernel_size
 
-    def process_present_mat(self, image: np.ndarray, cropout_mask: np.ndarray) -> np.ndarray:
+    def process(self, image: np.ndarray, cropout_mask: np.ndarray) -> np.ndarray:
         """
         Generate a binary mask for detecting mat-present regions using HSV thresholding.
 


### PR DESCRIPTION
added new approach to refining "missing_red" masks that include:
1. ExR (enhancing the effect of Red channel)
2. saturation thresholding to exclude gray mat (low saturation)

@navjot-nangia give this approach a review please (https://github.com/precision-sustainable-ag/Field-SegmentationTraining/blob/refine_missing_red/src/mask_gen_utils/missing_red.py)

@HaydenMcCleary and @MathewAaron might be interested in this too

Also included quick fix to `inspect.py` that had to do with looking in the right location for masks when only_include was not being used.


<img width="9544" height="2391" alt="NCB04902_0_grey_exr_blocks" src="https://github.com/user-attachments/assets/4f48e76c-2237-4127-94f7-e4a9aadae7c2" />


<img width="8815" height="2391" alt="NCA01474_0_grey_exr_blocks" src="https://github.com/user-attachments/assets/107a1da8-3b71-49e3-946d-518753d348a5" />


<img width="9559" height="2391" alt="NCA06244_0_grey_exr_blocks" src="https://github.com/user-attachments/assets/291bc2eb-3bbb-46ec-b467-17c282152ab9" />



