### PR TITLE
Finalize lts masks

### DIFF
--- a/conf/mask_gen/default.yaml
+++ b/conf/mask_gen/default.yaml
@@ -50,9 +50,8 @@ relabel:
   task_name: ${project.name}_relabeling
   label_field: refined_mask # either initial_mask or refined_mask
   only_tags:
-    - missing_white
+    # - missing_white
 
 export_cvat:
-  move_to_lts: true # Moves the exported annotations to the long-term storage directory and updates the path in the database.
   task_ids:
     - 295  # CVAT task ID for exporting annotations

--- a/conf/mask_gen/default.yaml
+++ b/conf/mask_gen/default.yaml
@@ -1,13 +1,13 @@
 inspect:
   dataset_name: testing_inspect_maskgen
   port: 5050
-  only_include_tags:
-    - missing_white
+  only_tags:
+    # - missing_white
 
 
 refine:
-  only_include_tags:
-    - missing_white
+  only_tags:
+    # - missing_white
   
   filter_db_by_final_voxel_tags: # filters the voxel database by specific final voxel tags 
     - good

--- a/conf/paths/default.yaml
+++ b/conf/paths/default.yaml
@@ -30,8 +30,8 @@ project_temp_db: ${paths.project_dir}/temp_db.csv
 
 # paths for mask_gen mode:
 mask_gen_cutout_dir: ${paths.project_maskgen_dir}/cutouts
-refined_masks_dir: ${paths.project_maskgen_dir}/refined_masks
-relabeled_masks_dir: ${paths.project_maskgen_dir}/relabeled_masks
+refined_dir: ${paths.project_maskgen_dir}/refined
+relabeled_dir: ${paths.project_maskgen_dir}/relabeled
 
 # longterm storage paths
 longterm_storage: /mnt/research-projects/r/raatwell/longterm_images3/

--- a/src/finalize_lts_utils/finalize_lts.py
+++ b/src/finalize_lts_utils/finalize_lts.py
@@ -88,22 +88,30 @@ class FinalizeMasks:
         assert not missing, f"Temp DB missing required columns: {missing}"
         return df
 
+    def _mask_is_finalized(self, row: pd.Series) -> bool:
+        return row.get("mask_status") == "finalized"
+
+    def _row_has_relabeled_mask(self, row: pd.Series) -> bool:
+        full_mask = row.get("temp_relabeled_full_mask_path")
+        cutout_png = row.get("temp_relabeled_cutout_image_path")
+        
+        if pd.isna(full_mask) or pd.isna(cutout_png):
+            log.warning(f"Row missing temp paths: {row.get('image_id')}")
+            return False
+
+        return Path(str(full_mask)).exists() and Path(str(cutout_png)).exists()
+
     def _row_is_ready(self, row: pd.Series) -> bool:
         """
         A conservative “ready to finalize” heuristic:
         - temp_relabeled_full_mask_path present (and file exists if checks on)
         - temp_relabeled_cutout_image_path present (and file exists if checks on)
         """
-        full_mask = row.get("temp_relabeled_full_mask_path")
-        cutout_png = row.get("temp_relabeled_cutout_image_path")
-
-        if pd.isna(full_mask) or pd.isna(cutout_png):
-            return False
-
-        if not self.file_checks:
+        if self._mask_is_finalized(row):
             return True
-
-        return Path(str(full_mask)).exists() and Path(str(cutout_png)).exists()
+        if self._row_has_relabeled_mask(row):
+            return True
+        return False
 
     def filter_rows_to_finalize(self, df: pd.DataFrame) -> pd.DataFrame:
         mask = df.apply(self._row_is_ready, axis=1)
@@ -152,11 +160,6 @@ class FinalizeMasks:
             image_id_stem = str(Path(image_id).stem)  # Ensure image_id is a string
             src_full_mask = Path(str(row["temp_relabeled_full_mask_path"]))
             src_cutout_png = Path(str(row["temp_relabeled_cutout_image_path"]))
-
-            # Assert that image_id_stem matches with full_mask stem and cutout stem
-            mask_stem = src_full_mask.stem.replace("_mask", "")
-            cutout_stem = src_cutout_png.stem.replace("_0", "")
-            assert image_id_stem == mask_stem == cutout_stem, f"ID mismatch: {image_id_stem}, {mask_stem}, {cutout_stem}"
 
             dst_full_mask = self._dest_for_full_mask(image_id_stem, src_full_mask)
             dst_cutout_png = self._dest_for_cutout_png(image_id_stem, src_cutout_png)
@@ -232,6 +235,10 @@ class FinalizeMasks:
                 "final_mask_issue_tag",
                 "final_mask_path",
                 "cutout_image_path",
+                "bbox_xywh",
+                "det_pred_conf",
+                "initial_mask_issue_tag",
+                "tags"
             ]
 
             existing_cols = [c for c in candidate_cols if self._column_exists(con, table, c)]
@@ -282,6 +289,8 @@ class FinalizeMasks:
 
         # 2) Filter rows ready to finalize (both temp files present)
         df_ready = self.filter_rows_to_finalize(df)
+        # print(df_ready)
+        # exit()
         
         if df_ready.empty:
             log.info("No rows ready to finalize. Nothing to do.")

--- a/src/mask_gen_utils/export_cvat.py
+++ b/src/mask_gen_utils/export_cvat.py
@@ -105,7 +105,7 @@ class CVATRelabelProcessor:
     COL_REFINE_PARAMS = "refine_params"
 
     STATUS_IGNORE = ["inspected", "good", "finalized", "unreviewed"]
-    STATUS_RELABELLED = "relabelled"
+    STATUS_RELABELED = "relabeled"
 
     BBOX_XYWH = "bbox_xywh"  # CVAT bbox format: [x, y, width, height]
 
@@ -188,7 +188,9 @@ class CVATRelabelProcessor:
             s = fo.Sample(filepath=str(img_p))
             initial_tag = row.get(self.COL_INIT_ISSUE_TAG)
             s["initial_tag"] = "" if pd.isna(initial_tag) else initial_tag
-            s["final_tag"] = (row.get(self.COL_FINAL_ISSUE_TAG) or "")
+            final_tag = row.get(self.COL_FINAL_ISSUE_TAG)
+            s["final_tag"] = "" if pd.isna(final_tag) else final_tag
+            print(f"\n\n\n\ns['final_tag']: {s['final_tag']}")
             s["tags"] = [t.strip().lower() for t in str(row.get(self.COL_TAGS) or "").split(",") if t.strip()]
             s["status"] = status
             reviewer = row.get(self.COL_REVIEWER)

--- a/src/mask_gen_utils/export_cvat.py
+++ b/src/mask_gen_utils/export_cvat.py
@@ -143,9 +143,7 @@ class CVATRelabelProcessor:
     # ---------- IO ----------
     def load_df(self) -> pd.DataFrame:
         self.df = pd.read_csv(self.temp_csv_path)
-        log.info(f"Loaded temp DB: {self.temp_csv_path} with {len(self.df)} rows")
-        print(self.df)
-        
+        log.info(f"Loaded temp DB: {self.temp_csv_path} with {len(self.df)} rows")        
 
     def save_df(self) -> None:
         assert self.df is not None, "No DataFrame loaded to save."

--- a/src/mask_gen_utils/export_cvat.py
+++ b/src/mask_gen_utils/export_cvat.py
@@ -49,7 +49,7 @@ def _combine_detection_masks_to_full_mask(
     Combine instance masks from detections into a full-resolution mask aligned to mask_shape_field.
     If detections or mask shape are missing, return the existing mask of mask_shape_field.
     """
-    if detections_field not in sample or mask_shape_field not in sample:
+    if detections_field not in sample or mask_shape_field not in sample or sample[detections_field] is None:
         return sample[mask_shape_field].mask
 
     relabeled_dets = sample[detections_field]["detections"]
@@ -104,7 +104,7 @@ class CVATRelabelProcessor:
     COL_FINAL_ISSUE_TAG = "final_mask_issue_tag"
     COL_REFINE_PARAMS = "refine_params"
 
-    STATUS_IGNORE = ["inspected", "good", "finalized", "unreviewed"]
+    STATUS_IGNORE = ["inspected", "good", "finalized", "unreviewed", "bad"]
     STATUS_RELABELED = "relabeled"
 
     BBOX_XYWH = "bbox_xywh"  # CVAT bbox format: [x, y, width, height]
@@ -113,7 +113,6 @@ class CVATRelabelProcessor:
         self.cfg = cfg
         self.repo_root = Path(cfg.paths.base_dir).resolve()
         self.temp_csv_path = Path(cfg.paths.project_temp_db).resolve()
-        self.output_relabeled_dir = Path(cfg.paths.relabeled_masks_dir).resolve()
 
         # Review/meta
         self.reviewer = os.getenv("USER") or "unknown"
@@ -134,11 +133,8 @@ class CVATRelabelProcessor:
         self.dataset: Optional[fo.Dataset] = None
 
         # Prepare output directories
-        self.output_full_masks_dir = Path(cfg.paths.project_maskgen_dir) / "final_fullsized_masks"
-        self.output_full_masks_dir.mkdir(parents=True, exist_ok=True)
-
-        self.output_cutout_images_dir = Path(cfg.paths.project_maskgen_dir) / "relabeled_cutouts"
-        self.output_cutout_images_dir.mkdir(parents=True, exist_ok=True)
+        self.output_relabeled_dir = Path(cfg.paths.relabeled_dir).resolve()
+        self.output_relabeled_dir.mkdir(parents=True, exist_ok=True)
 
     # ---------- IO ----------
     def load_df(self) -> pd.DataFrame:
@@ -427,7 +423,7 @@ class CVATRelabelProcessor:
 
             # Save
             base_name = Path(row.get(self.COL_TEMP_INITIAL_IMG, Path(rel_cutout_path).stem)).stem
-            out_path = self.output_full_masks_dir / f"{base_name}_mask.png"
+            out_path = self.output_relabeled_dir / f"{base_name}_mask.png"
             cv2.imwrite(str(out_path), canvas)
 
             # Update CSV with repo-relative path if possible
@@ -493,7 +489,7 @@ class CVATRelabelProcessor:
 
             # Save PNG with transparency
             base_stem = Path(cutout_img_path).stem
-            out_path = self.output_cutout_images_dir / f"{base_stem}.png"
+            out_path = self.output_relabeled_dir / f"{base_stem}.png"
             if not cv2.imwrite(str(out_path), masked_bgr):
                 log.warning(f"[row {idx}] Failed to write masked cutout image: {out_path}")
                 continue

--- a/src/mask_gen_utils/export_cvat.py
+++ b/src/mask_gen_utils/export_cvat.py
@@ -188,9 +188,10 @@ class CVATRelabelProcessor:
             s = fo.Sample(filepath=str(img_p))
             initial_tag = row.get(self.COL_INIT_ISSUE_TAG)
             s["initial_tag"] = "" if pd.isna(initial_tag) else initial_tag
+
             final_tag = row.get(self.COL_FINAL_ISSUE_TAG)
             s["final_tag"] = "" if pd.isna(final_tag) else final_tag
-            print(f"\n\n\n\ns['final_tag']: {s['final_tag']}")
+            
             s["tags"] = [t.strip().lower() for t in str(row.get(self.COL_TAGS) or "").split(",") if t.strip()]
             s["status"] = status
             reviewer = row.get(self.COL_REVIEWER)

--- a/src/mask_gen_utils/export_cvat.py
+++ b/src/mask_gen_utils/export_cvat.py
@@ -104,7 +104,7 @@ class CVATRelabelProcessor:
     COL_FINAL_ISSUE_TAG = "final_mask_issue_tag"
     COL_REFINE_PARAMS = "refine_params"
 
-    STATUS_IGNORE = ["inspected", "good", "finalized"]
+    STATUS_IGNORE = ["inspected", "good", "finalized", "unreviewed"]
     STATUS_RELABELLED = "relabelled"
 
     BBOX_XYWH = "bbox_xywh"  # CVAT bbox format: [x, y, width, height]
@@ -188,11 +188,13 @@ class CVATRelabelProcessor:
                 continue
 
             s = fo.Sample(filepath=str(img_p))
-            s["initial_tag"] = (row.get(self.COL_INIT_ISSUE_TAG) or "")
+            initial_tag = row.get(self.COL_INIT_ISSUE_TAG)
+            s["initial_tag"] = "" if pd.isna(initial_tag) else initial_tag
             s["final_tag"] = (row.get(self.COL_FINAL_ISSUE_TAG) or "")
             s["tags"] = [t.strip().lower() for t in str(row.get(self.COL_TAGS) or "").split(",") if t.strip()]
             s["status"] = status
-            s["reviewer"] = (row.get(self.COL_REVIEWER) or self.reviewer)
+            reviewer = row.get(self.COL_REVIEWER)
+            s["reviewer"] = "" if pd.isna(reviewer) else reviewer
             s["timestamp"] = (row.get(self.COL_TIMESTAMP) or self.run_timestamp)
 
             rp = row.get(self.COL_REFINE_PARAMS)

--- a/src/mask_gen_utils/export_cvat.py
+++ b/src/mask_gen_utils/export_cvat.py
@@ -105,7 +105,7 @@ class CVATRelabelProcessor:
     COL_REFINE_PARAMS = "refine_params"
 
     STATUS_IGNORE = ["inspected", "good", "finalized", "unreviewed"]
-    STATUS_RELABELLED = "relabelled"
+    STATUS_RELABELED = "relabeled"
 
     BBOX_XYWH = "bbox_xywh"  # CVAT bbox format: [x, y, width, height]
 
@@ -251,7 +251,7 @@ class CVATRelabelProcessor:
         Returns a dict keyed by image absolute path with per-sample updates:
           {
             "/abs/path/to/image.jpg": {
-              "status": "relabelled" | original_status,
+              "status": "relabeled" | original_status,
               "mask_path": "/abs/path/to/saved/_mask.png" | "",
               "reviewer": "...",
               "timestamp": "..."
@@ -275,7 +275,7 @@ class CVATRelabelProcessor:
 
             changed = not _same_masks(refined_mask, relabeled_mask)
             if changed:
-                status = self.STATUS_RELABELLED
+                status = self.STATUS_RELABELED
                 reviewer = self.reviewer
                 timestamp = self.run_timestamp
                 mask_path = str(self._save_relabeled_mask_png(sample))

--- a/src/mask_gen_utils/inspect.py
+++ b/src/mask_gen_utils/inspect.py
@@ -332,7 +332,7 @@ class FiftyOneMaskInspector:
             initial_tag = str(initial_tag).lower() if pd.notna(initial_tag) else None
 
             if "good" in tags_set:
-                final_tag, status = "good", "finalized"
+                final_tag, status = "finalized", "finalized"
             elif "bad" in tags_set:
                 final_tag, status = "bad", "reviewed"
             elif "other" in tags_set:

--- a/src/mask_gen_utils/inspect.py
+++ b/src/mask_gen_utils/inspect.py
@@ -194,7 +194,7 @@ class FiftyOneMaskInspector:
         df = self.df
 
         # By default: anything not final-reviewed
-        mask = (df["mask_status"].isna()) | (df["mask_status"].isin(["unreviewed", "inspected", "refined", "relabelled"]))
+        mask = (df["mask_status"].isna()) | (df["mask_status"].isin(["unreviewed", "inspected", "refined", "relabeled"]))
         if self.only_tags:
             # Example semantics:
             #   only_tags: ["unreviewed"] or ["good","bad"] etc.

--- a/src/mask_gen_utils/missing_white.py
+++ b/src/mask_gen_utils/missing_white.py
@@ -66,13 +66,20 @@ class MissingWhite:
         Returns:
             np.ndarray: Binary mask with white regions as 255.
         """
-        # Separate the channels from RGB image
-        R = image[:, :, 0].astype(np.float32)
-        G = image[:, :, 1].astype(np.float32)
-        B = image[:, :, 2].astype(np.float32)
+        r = image[:, :, 0].astype(np.float32)
+        g = image[:, :, 1].astype(np.float32)
+        b = image[:, :, 2].astype(np.float32)
+
+        # Normalize the channels
+        r_norm, g_norm, b_norm = r / 255.0, g / 255.0, b / 255.0
+
+        # Linearize the RGB values to convert the default gamma-corrected RGB values to linear RGB values.
+        r_lin = np.where(r_norm < 0.04045, r_norm / 12.92, ((r_norm + 0.055) / 1.055) ** 2.4)
+        g_lin = np.where(g_norm < 0.04045, g_norm / 12.92, ((g_norm + 0.055) / 1.055) ** 2.4)
+        b_lin = np.where(b_norm < 0.04045, b_norm / 12.92, ((b_norm + 0.055) / 1.055) ** 2.4)
 
         # Calculate luminance index
-        luminance = 0.2126 * R + 0.7152 * G + 0.0722 * B
+        luminance = 0.2126 * r_lin + 0.7152 * g_lin + 0.0722 * b_lin
 
         # Apply luminance threshold
         if self.luminance_thresh > 0:

--- a/src/mask_gen_utils/refine.py
+++ b/src/mask_gen_utils/refine.py
@@ -19,12 +19,16 @@ log = logging.getLogger(__name__)
 
 # Columns we’ll ensure exist in the temp CSV
 REFINE_COLS = [
+    "temp_refined_cutout_path",
     "temp_refined_cutout_mask_path",
+    "temp_refined_full_mask_path",
     "refine_params",              # JSON string of the config used for this refine op
     "mask_status",                # keep in sync with inspect.py
     "mask_reviewer",
     "mask_timestamp",
 ]
+
+COL_TEMP_INITIAL_CUTOUT_IMG = "temp_initial_cutout_path"
 
 class RefineMask:
     """
@@ -39,8 +43,8 @@ class RefineMask:
         self.repo_root = Path(cfg.paths.base_dir).resolve()
         self.maskgen_dir = Path(cfg.paths.project_maskgen_dir).resolve()
         self.cutout_dir = self.maskgen_dir / "cutouts"
-        self.refined_mask_dir = self.maskgen_dir / "refined_masks"
-        self.refined_mask_dir.mkdir(parents=True, exist_ok=True)
+        self.refined_dir = Path(cfg.paths.refined_dir).resolve()
+        self.refined_dir.mkdir(parents=True, exist_ok=True)
 
         # Input/Output “temp db”
         self.temp_csv = Path(cfg.paths.project_temp_db)
@@ -160,13 +164,13 @@ class RefineMask:
         params = OmegaConf.to_container(proc_cfg, resolve=True)
         return refined, params
 
-    def _save_refined(self, refined_mask: np.ndarray, src_mask_path: Path) -> Path:
+    def _save_refined_cutout_mask(self, refined_mask: np.ndarray, src_mask_path: Path) -> Path:
         """
         Save refined mask alongside project refined_masks dir.
         We mirror the cutout mask's filename into refined_masks/.
         """
         name = src_mask_path.name  # e.g., <stem>_0_mask.png
-        out_path = (self.refined_mask_dir / name).resolve()
+        out_path = (self.refined_dir / name).resolve()
 
         # Normalize to 0/255 uint8 before saving
         m = refined_mask
@@ -177,6 +181,61 @@ class RefineMask:
 
         cv2.imwrite(str(out_path), m)
         return out_path
+
+    def _save_fullsized_mask(self, row: pd.Series, cutout_mask_path: np.ndarray) -> np.ndarray:
+        """
+        Create a full-sized mask (same size as original image) from the cutout mask.
+        The cutout_path is used to determine the position of the cutout within the full image.
+        """
+        initial_full_mask_path = row.get("temp_initial_mask_path", None)
+        initial_mask = cv2.imread(str(initial_full_mask_path), cv2.IMREAD_GRAYSCALE)
+        full_image_shape = initial_mask.shape
+
+        refined_cutout_mask = cv2.imread(str(cutout_mask_path), cv2.IMREAD_GRAYSCALE)
+        if refined_cutout_mask is None:
+            raise FileNotFoundError(f"Could not read cutout mask for full-sized mask creation: {cutout_mask_path}")
+        
+        bbox_val = row.get("bbox_xywh", None)
+        if isinstance(bbox_val, str):
+            bbox_xywh = json.loads(bbox_val) if bbox_val.strip().startswith("[") else [float(v) for v in bbox_val.split(",")]
+        elif isinstance(bbox_val, (list, tuple, np.ndarray, pd.Series)):
+            bbox_xywh = list(bbox_val)
+        x, y, w, h = bbox_xywh[0], bbox_xywh[1], bbox_xywh[2], bbox_xywh[3]
+
+        full_mask = np.zeros(full_image_shape, dtype=np.uint8)
+        full_mask[y:y+h, x:x+w] = (refined_cutout_mask > 0).astype(np.uint8) * 255.
+
+        # Save PNG with transparency
+        cutout_path = str(cutout_mask_path).replace("_mask.png", ".png")
+        base_stem = Path(cutout_path).stem
+        # Remove the leading _0 from the stem if present
+        if base_stem.endswith("_0"):
+            base_stem = base_stem[:-2]
+        out_path = self.refined_dir / f"{base_stem}_mask.png"
+        cv2.imwrite(str(out_path), full_mask)
+        return out_path
+
+    def _save_refined_cutout(self, out_path: Path, row: pd.Series) -> Path:
+        """
+        Create a new masked cutout image using the relabeled cutout mask.
+        Saves as RGBA PNG with transparency from the mask.
+        """        
+        initial_cropout_path = row.get(COL_TEMP_INITIAL_CUTOUT_IMG, None)
+        cutout_bgr = cv2.imread(str(initial_cropout_path), cv2.IMREAD_COLOR)
+        mask_gray = cv2.imread(str(out_path), cv2.IMREAD_GRAYSCALE)
+        # Ensure mask is binary 0/255 uint8
+        mask_bin = (mask_gray > 0).astype(np.uint8)
+        # Expand to 3 channels and apply
+        mask_3c = np.repeat(mask_bin[:, :, None], 3, axis=2)
+        masked_bgr = cutout_bgr * mask_3c  # background → black
+
+        # Save PNG with transparency
+        base_stem = Path(initial_cropout_path).stem
+        out_path = self.refined_dir / f"{base_stem}.png"
+
+        cv2.imwrite(str(out_path), masked_bgr)
+        return out_path
+
 
     # ---------------- Public run ----------------
 
@@ -203,16 +262,25 @@ class RefineMask:
 
             try:
                 refined_mask, params = self._run_processor(tag_key, image_bgr, mask_gray)
-                out_path = self._save_refined(refined_mask, paths["mask"])
+                refined_cutout_mask_path = self._save_refined_cutout_mask(refined_mask, paths["mask"])
+                refined_cutout_path = self._save_refined_cutout(refined_cutout_mask_path, row)
+                refined_full_mask_path = self._save_fullsized_mask(row, refined_cutout_mask_path)   
+
 
                 # Prefer repo-relative path when possible
                 try:
-                    rel = out_path.relative_to(self.repo_root)
+                    rel_cut_mask = refined_cutout_mask_path.relative_to(self.repo_root)
+                    rel_cut = refined_cutout_path.relative_to(self.repo_root)
+                    rel_full_mask = refined_full_mask_path.relative_to(self.repo_root)
                 except ValueError:
-                    rel = out_path
+                    rel_cut_mask = refined_cutout_mask_path
+                    rel_cut = refined_cutout_path
+                    rel_full_mask = refined_full_mask_path
 
                 # Update row
-                self.df.at[idx, "temp_refined_cutout_mask_path"] = str(rel)
+                self.df.at[idx, "temp_refined_cutout_mask_path"] = str(rel_cut_mask)
+                self.df.at[idx, "temp_refined_cutout_path"] = str(rel_cut)
+                self.df.at[idx, "temp_refined_full_mask_path"] = str(rel_full_mask)
                 self.df.at[idx, "refine_params"] = json.dumps(params)
                 self.df.at[idx, "mask_status"] = "refined"
                 self.df.at[idx, "mask_reviewer"] = self.reviewer
@@ -220,7 +288,7 @@ class RefineMask:
                 updated += 1
 
             except Exception as e:
-                log.warning(f"Refine error on row {idx} ({tag_key}): {e}")
+                log.exception(f"Refine error on row {idx} ({tag_key}): {e}")
                 skipped += 1
 
         log.info(f"Refine complete — updated: {updated}, skipped: {skipped}, missing: {missing}")

--- a/src/mask_gen_utils/upload_cvat.py
+++ b/src/mask_gen_utils/upload_cvat.py
@@ -25,7 +25,7 @@ NEEDED_COLS = [
     "initial_mask_issue_tag",          # e.g., "missing_red"
     "final_mask_issue_tag",            # optional override/after-inspect tag
     "tags",                            # comma separated
-    "mask_status",                     # unreviewed|refined|cvat_uploaded|relabelled|...
+    "mask_status",                     # unreviewed|refined|cvat_uploaded|relabeled|...
     "mask_reviewer",
     "mask_timestamp",
     "refine_params",                   # json string
@@ -159,7 +159,7 @@ class UploadToCVAT:
 
             # Skip rows already uploaded or finished unless you want to re-upload
             status = (row.get("mask_status") or "").strip().lower()
-            if status in {"cvat_uploaded", "relabelled"}:
+            if status in {"cvat_uploaded", "relabeled"}:
                 log.warning(f"Skipping row {idx} with status '{status}'")
                 continue
 

--- a/src/mask_gen_utils/upload_cvat.py
+++ b/src/mask_gen_utils/upload_cvat.py
@@ -39,9 +39,7 @@ class UploadToCVAT:
     def __init__(self, cfg: DictConfig) -> None:
         self.cfg = cfg
         self.repo_root = Path(cfg.paths.base_dir).resolve()
-        self.maskgen_dir = Path(cfg.paths.project_maskgen_dir).resolve()
-        self.cutout_dir = self.maskgen_dir / "cutouts"
-        self.refined_mask_dir = self.maskgen_dir / "refined_masks"
+        self.cutout_dir = Path(cfg.paths.mask_gen_cutout_dir).resolve()
 
         self.temp_csv = Path(cfg.paths.project_temp_db)
         if not self.temp_csv.exists():

--- a/src/mask_gen_utils/upload_cvat.py
+++ b/src/mask_gen_utils/upload_cvat.py
@@ -175,14 +175,14 @@ class UploadToCVAT:
 
             # Build sample
             s = fo.Sample(filepath=str(paths["image"]))
-            s["initial_tag"] = (row.get("initial_mask_issue_tag") or "")  # keep raw
-            s["final_tag"] = (row.get("final_mask_issue_tag") or "")
+            s["initial_tag"] = str(row.get("initial_mask_issue_tag") or "")  # keep raw
+            s["final_tag"] = str(row.get("final_mask_issue_tag") or "")
             s["tags"] = self._split_tags(row.get("tags"))
 
             # carry reviewer/timestamp/refine_params forward
             s["status"] = status or ""
-            s["reviewer"] = (row.get("mask_reviewer") or self.reviewer)
-            s["timestamp"] = (row.get("mask_timestamp") or self.timestamp)
+            s["reviewer"] = str(row.get("mask_reviewer") or self.reviewer)
+            s["timestamp"] = str(row.get("mask_timestamp") or self.timestamp)
             rp = row.get("refine_params")
             s["refine_params"] = rp if (rp and isinstance(rp, str)) else "{}"
 


### PR DESCRIPTION
Setup logic to save all "finalized" or "good" masks to LTS whether they are the `initial`, `refined`, or `relabeled` mask, and update the db with all the necessary fields.

- [x] Mark any masks with "good" tags as "finalized"  mask_status in the temporary db. Do this during `inspect`.
- [x] Create logic in `finalize` mode so that all "finalized" masks are sent to LTS
- [x] Cutouts got to ` /mnt/research-projects/r/raatwell/longterm_images3/field-cutouts/`
- [x] Final masks go to ` /mnt/research-projects/r/raatwell/longterm_images3/field-masks/`
- [x] Consolidate refined and relabeled products into a respective folders
- [x] store refined and relabeled cutout, cutout mask, and fullsize mask in temp db
  -  this allow us to refer to it later when we move it to LTS

Note: Use `/mnt/research-projects/r/raatwell/longterm_images3/field-tools/agir_field_db/agir_field_test.db` for testing.