### PR TITLE
Add vegetation cutout functionality

### DIFF
--- a/conf/inference/default.yaml
+++ b/conf/inference/default.yaml
@@ -10,6 +10,7 @@ save:
   overlay: true
   raw_mask: true
   cutout: true
+  metadata: true     # save original detection bbox + tightened cutout bbox as JSON
 overlay:
   alpha: 0.60
   color: [0, 255, 0]                       # green
@@ -22,11 +23,17 @@ roi:
   conf: 0.25
   iou: 0.45
   pick: "best"                             # "best" (highest conf) or "largest"
+  detection_padding: 
+    enabled: false         # add padding to the detected ROI before segmentation (to ensure full plant is captured)
+    pad_px: 200            # pixels to pad on each side of the detected bounding box
 
 # Segmentation & pre/post
 seg:
   weights_path: ${paths.unet_segmentation_model}  # glob allowed; latest picked
-  threshold: 0.5
+  threshold: 0.75
+  clean_disconnected_mask:
+    enable: false
+    min_area_px: 500
   pad_to_divisor: 32                     # pad input so H,W divisible by this (for UNet or any other model with downsamplings)
   tile:
     enable: True

--- a/conf/inference/default.yaml
+++ b/conf/inference/default.yaml
@@ -9,6 +9,7 @@ save:
   triptych: true
   overlay: true
   raw_mask: true
+  cutout: true
 overlay:
   alpha: 0.60
   color: [0, 255, 0]                       # green

--- a/src/inference_utils/inference_lts.py
+++ b/src/inference_utils/inference_lts.py
@@ -17,6 +17,7 @@ from src.inference_utils.inference_pipeline import (
     _read_rgb,
     _overlay_rgb_mask,
     _save_triptych,
+    _save_vegetation_cutout,
     _to_tensor01,
     _pad_to_divisor,
     _unpad,
@@ -176,6 +177,7 @@ def run_inference_lts(cfg: DictConfig) -> None:
     (run_dir / "masks").mkdir(parents=True, exist_ok=True)
     (run_dir / "overlays").mkdir(parents=True, exist_ok=True)
     (run_dir / "triptych").mkdir(parents=True, exist_ok=True)
+    (run_dir / "cutouts").mkdir(parents=True, exist_ok=True)   # ← NEW
 
     # W&B (optional)
     wb_cfg = cfg.inference.logger.wandb if "logger" in cfg.inference and "wandb" in cfg.inference.logger else {}
@@ -215,6 +217,7 @@ def run_inference_lts(cfg: DictConfig) -> None:
     max_side = int(cfg.inference.preview_max_side)
     tile_cfg = getattr(cfg.inference.seg, "tile", None)
     norm_cfg = getattr(cfg.inference, "normalization", None)
+    save_cutout = bool(getattr(getattr(cfg.inference, "save", {}), "cutout", False))
 
     # Load image list from LTS database
     df = _load_lts_rows(cfg)
@@ -236,10 +239,10 @@ def run_inference_lts(cfg: DictConfig) -> None:
         if roi is None:
             # No ROI → use the full image
             x1, y1, x2, y2 = 0, 0, W, H
-            crop = rgb[y1:y2, x1:x2].copy()
         else:
-            crop = rgb.copy()
-            x1, y1 = 0, 0
+            x1, y1, x2, y2 = roi                                    
+
+        crop = rgb[y1:y2, x1:x2].copy()
 
         # Tiled vs Single-shot
         if tile_cfg and tile_cfg.enable:
@@ -287,6 +290,16 @@ def run_inference_lts(cfg: DictConfig) -> None:
                        run_dir / "triptych" / f"{stem}_triptych.png",
                        max_side=max_side)
 
+        # ── vegetation cutout ──────────────────────────────────────
+        if save_cutout:
+            _save_vegetation_cutout(
+                crop_rgb=crop,
+                mask_crop=mask_crop,
+                out_path=run_dir / "cutouts" / f"{stem}_cutout.png",
+                max_side=max_side,
+            )
+        # ───────────────────────────────────────────────────────────────
+
         # W&B per-image logging
         if use_wandb:
             try:
@@ -296,6 +309,11 @@ def run_inference_lts(cfg: DictConfig) -> None:
                     "inference_LTS/overlay": wandb.Image(str(run_dir / "overlays" / f"{stem}_overlay.png")),
                     "inference_LTS/triptych": wandb.Image(str(run_dir / "triptych" / f"{stem}_triptych.png")),
                 })
+                if save_cutout:                                               # ← NEW
+                    to_log["inference_LTS/cutout"] = wandb.Image(            # ← NEW
+                        str(run_dir / "cutouts" / f"{stem}_cutout.png")      # ← NEW
+                    )                                                         # ← NEW
+                wandb.log(to_log)
             except Exception as e:
                 log.debug(f"[LTS] W&B log failed: {e}")
 

--- a/src/inference_utils/inference_lts.py
+++ b/src/inference_utils/inference_lts.py
@@ -9,7 +9,7 @@ import pandas as pd
 import cv2
 import numpy as np
 import torch
-
+from typing import Any, cast
 from hydra.core.hydra_config import HydraConfig
 from omegaconf import DictConfig, OmegaConf
 
@@ -18,6 +18,7 @@ from src.inference_utils.inference_pipeline import (
     _overlay_rgb_mask,
     _save_triptych,
     _save_vegetation_cutout,
+    _save_metadata_json,
     _to_tensor01,
     _pad_to_divisor,
     _unpad,
@@ -191,7 +192,7 @@ def run_inference_lts(cfg: DictConfig) -> None:
                 entity=wb_cfg.get("entity", None),
                 name=wb_cfg.get("run_name", stamp),
                 dir=str(run_dir),
-                config=OmegaConf.to_container(cfg, resolve=True),
+                config=cast(dict[str, Any], OmegaConf.to_container(cfg, resolve=True)),
                 save_code=False,
                 reinit=True,
             )
@@ -302,6 +303,7 @@ def run_inference_lts(cfg: DictConfig) -> None:
 
         # ── vegetation cutout ──────────────────────────────────────
         if save_cutout:
+            assert seg_cfg is not None, "seg config must be provided to save cutouts"
             cutout_meta = _save_vegetation_cutout(
                 seg_cfg=seg_cfg,
                 crop_rgb=crop,
@@ -324,15 +326,15 @@ def run_inference_lts(cfg: DictConfig) -> None:
         if use_wandb:
             try:
                 import wandb
-                wandb.log({
+                to_log = {
                     "inference_LTS/mask": wandb.Image(str(run_dir / "masks" / f"{stem}.png")),
                     "inference_LTS/overlay": wandb.Image(str(run_dir / "overlays" / f"{stem}_overlay.png")),
                     "inference_LTS/triptych": wandb.Image(str(run_dir / "triptych" / f"{stem}_triptych.png")),
-                })
-                if save_cutout:                                               # ← NEW
-                    to_log["inference_LTS/cutout"] = wandb.Image(            # ← NEW
-                        str(run_dir / "cutouts" / f"{stem}_cutout.png")      # ← NEW
-                    )                                                         # ← NEW
+                }
+                if save_cutout:
+                    to_log["inference_LTS/cutout"] = wandb.Image(
+                        str(run_dir / "cutouts" / f"{stem}_cutout.png")
+                    )
                 wandb.log(to_log)
             except Exception as e:
                 log.debug(f"[LTS] W&B log failed: {e}")

--- a/src/inference_utils/inference_lts.py
+++ b/src/inference_utils/inference_lts.py
@@ -177,7 +177,8 @@ def run_inference_lts(cfg: DictConfig) -> None:
     (run_dir / "masks").mkdir(parents=True, exist_ok=True)
     (run_dir / "overlays").mkdir(parents=True, exist_ok=True)
     (run_dir / "triptych").mkdir(parents=True, exist_ok=True)
-    (run_dir / "cutouts").mkdir(parents=True, exist_ok=True)   # ← NEW
+    (run_dir / "cutouts").mkdir(parents=True, exist_ok=True)
+    (run_dir / "metadata").mkdir(parents=True, exist_ok=True)
 
     # W&B (optional)
     wb_cfg = cfg.inference.logger.wandb if "logger" in cfg.inference and "wandb" in cfg.inference.logger else {}
@@ -218,6 +219,9 @@ def run_inference_lts(cfg: DictConfig) -> None:
     tile_cfg = getattr(cfg.inference.seg, "tile", None)
     norm_cfg = getattr(cfg.inference, "normalization", None)
     save_cutout = bool(getattr(getattr(cfg.inference, "save", {}), "cutout", False))
+    save_metadata = bool(getattr(getattr(cfg.inference, "save", {}), "metadata", False))
+    roi_cfg = getattr(cfg.inference, "roi", None)
+    seg_cfg = getattr(cfg.inference, "seg", None)
 
     # Load image list from LTS database
     df = _load_lts_rows(cfg)
@@ -235,12 +239,18 @@ def run_inference_lts(cfg: DictConfig) -> None:
 
         H, W = rgb.shape[:2]
 
-        roi = _detect_roi_if_enabled(cfg, rgb)
+        roi = _detect_roi_if_enabled(roi_cfg, rgb)
         if roi is None:
             # No ROI → use the full image
             x1, y1, x2, y2 = 0, 0, W, H
         else:
-            x1, y1, x2, y2 = roi                                    
+            x1, y1, x2, y2 = roi     
+        
+        pad_cfg = getattr(roi_cfg, "detection_padding", {}) if roi_cfg else {}
+        pad_px = int(getattr(pad_cfg, "pad_px", 0))
+        bbox_was_padded = bool(
+            roi is not None and getattr(pad_cfg, "enabled", False) and pad_px > 0
+        )                               
 
         crop = rgb[y1:y2, x1:x2].copy()
 
@@ -292,12 +302,22 @@ def run_inference_lts(cfg: DictConfig) -> None:
 
         # ── vegetation cutout ──────────────────────────────────────
         if save_cutout:
-            _save_vegetation_cutout(
+            cutout_meta = _save_vegetation_cutout(
+                seg_cfg=seg_cfg,
                 crop_rgb=crop,
                 mask_crop=mask_crop,
                 out_path=run_dir / "cutouts" / f"{stem}_cutout.png",
-                max_side=max_side,
+                crop_origin_xy=(x1, y1),
+                detection_bbox_xyxy=roi,
+                detection_bbox_padded=bbox_was_padded,
+                detection_pad_px=pad_px
             )
+            if save_metadata:
+                _save_metadata_json(
+                    run_dir / "metadata" / f"{stem}.json",
+                    image_name=img_path.name,
+                    meta=cutout_meta,
+                )
         # ───────────────────────────────────────────────────────────────
 
         # W&B per-image logging

--- a/src/inference_utils/inference_pipeline.py
+++ b/src/inference_utils/inference_pipeline.py
@@ -43,11 +43,10 @@ def _pad_to_divisor(x: torch.Tensor, divisor: Optional[int]) -> tuple[torch.Tens
     x_pad = F.pad(x, pad, mode="constant", value=0.0)
     return x_pad, (pad[2], pad[3], pad[0], pad[1])  # (top, bottom, left, right)
 
-def _unpad(arr: np.ndarray, pads: Tuple) -> np.ndarray:
-    """Remove padding added by _pad_to_divisor from a 2-D mask array."""
-    _, pad_w, _, pad_h = pads
-    H, W = arr.shape
-    return arr[: H - pad_h if pad_h else H, : W - pad_w if pad_w else W]
+def _unpad(np_img: np.ndarray, pads: Tuple[int,int,int,int]) -> np.ndarray:
+    t, b, l, r = pads
+    H, W = np_img.shape[:2]
+    return np_img[t:H - b if b > 0 else H, l:W - r if r > 0 else W]
 
 
 def _normalize_if_configured(x01: torch.Tensor, norm_cfg) -> torch.Tensor:
@@ -116,40 +115,137 @@ def _save_triptych(rgb: np.ndarray, mask_u8: np.ndarray, overlay: np.ndarray, ou
 
 
 # ─────────────────────────────────────────────────────────────
-# vegetation cutout helper
+# vegetation cutout helpers
 # ─────────────────────────────────────────────────────────────
 
+def _clean_disconnected_mask(bin_mask: np.ndarray, max_gap_px: float) -> np.ndarray:
+    kernel = np.ones((3, 3), np.uint8)
+    # Used only to decide connectivity/grouping — breaks 1-2px noise bridges
+    # without affecting which original pixels end up in the final mask.
+    label_src = cv2.morphologyEx(bin_mask, cv2.MORPH_OPEN, kernel, iterations=1)
+
+    num, labels, stats, _ = cv2.connectedComponentsWithStats(label_src, connectivity=4)
+    if num <= 2:
+        return bin_mask
+
+    areas = stats[1:, cv2.CC_STAT_AREA]
+    largest_label = 1 + int(np.argmax(areas))
+    main_mask = (labels == largest_label).astype(np.uint8)
+    dist_to_main = cv2.distanceTransform(1 - main_mask, cv2.DIST_L2, 5)
+
+    # Re-label the ORIGINAL (unopened) mask so we don't lose real pixels
+    # that the opening removed, then decide per-original-component using
+    # distance from the (opened) main_mask.
+    num_o, labels_o, stats_o, _ = cv2.connectedComponentsWithStats(bin_mask, connectivity=4)
+    cleaned = np.zeros_like(bin_mask)
+    for label in range(1, num_o):
+        comp_pixels = (labels_o == label)
+        min_dist = dist_to_main[comp_pixels].min()
+        if min_dist <= max_gap_px:
+            cleaned[comp_pixels] = 1
+    return cleaned
+
+def _clean_speckle_mask(bin_mask: np.ndarray, min_area: int) -> np.ndarray:
+    """Drop isolated small blobs from a binary mask, always keeping the
+    largest connected component. Used to strip stray speckles that can
+    appear far from the plant when segmentation runs on the full frame
+    (i.e. no detection/ROI to constrain it).
+    """
+    num, labels, stats, _ = cv2.connectedComponentsWithStats(bin_mask, connectivity=8)
+    if num <= 2:  # background + at most one foreground component already
+        return bin_mask
+    areas = stats[1:, cv2.CC_STAT_AREA]
+    largest_label = 1 + int(np.argmax(areas))
+    cleaned = np.zeros_like(bin_mask)
+    for label in range(1, num):
+        if label == largest_label or stats[label, cv2.CC_STAT_AREA] >= min_area:
+            cleaned[labels == label] = 1
+    return cleaned
+
+def _tight_bbox_from_mask(mask: np.ndarray) -> Optional[Tuple[int, int, int, int]]:
+    """
+    Tight bounding box (x1, y1, x2, y2) — end-exclusive — around all non-zero
+    pixels of a crop-space binary mask. Returns None if mask has no foreground.
+    """
+    bin_mask = mask > 0
+    rows = np.any(bin_mask, axis=1)
+    cols = np.any(bin_mask, axis=0)
+    if not rows.any() or not cols.any():
+        return None
+    y_idx = np.where(rows)[0]
+    x_idx = np.where(cols)[0]
+    y1, y2 = int(y_idx[0]), int(y_idx[-1]) + 1
+    x1, x2 = int(x_idx[0]), int(x_idx[-1]) + 1
+    return x1, y1, x2, y2
+
+
+def _save_metadata_json(out_path: Path, image_name: str, meta: dict) -> None:
+    payload = {"image": image_name, **meta}
+    with open(out_path, "w") as f:
+        json.dump(payload, f, indent=2)
+
 def _save_vegetation_cutout(
+    seg_cfg: DictConfig,
     crop_rgb: np.ndarray,
     mask_crop: np.ndarray,
     out_path: Path,
-) -> None:
-    """Save a vegetation segment (cutout) on a pure-black background.
+    crop_origin_xy: Tuple[int, int],
+    detection_bbox_xyxy: Optional[Tuple[int, int, int, int]] = None,
+    detection_bbox_padded: bool = False,
+    detection_pad_px: int = 0,
+) -> dict:
+    bin_mask = (mask_crop > 0).astype(np.uint8)
 
-    The cutout is produced by applying the crop-space segmentation mask to
-    the detection crop.  Every pixel outside the mask is set to black
-    (0, 0, 0).  Output is always full-resolution — no downscaling.
+    speckles_removed = False
+    if getattr(seg_cfg.clean_disconnected_mask, "enable", False):
+        pad_gap_px = getattr(seg_cfg.clean_disconnected_mask, "pad_px", 500)
+        cleaned = _clean_disconnected_mask(bin_mask, max_gap_px=pad_gap_px)
+        speckles_removed = bool(np.any(cleaned != bin_mask))
+        bin_mask = cleaned
 
-    Args:
-        crop_rgb:  Detection crop in RGB uint8 [H, W, 3].
-        mask_crop: Binary mask aligned to ``crop_rgb``, values in {0, 1}
-                   (or {0, 255}).  Pixels where mask > 0 are kept; all
-                   others become black.
-        out_path:  Destination PNG file path.
-    """
-    # Normalise mask to strict binary {0, 1}
-    bin_mask = (mask_crop > 0).astype(np.uint8)                   # [H, W]
-    mask_3c  = np.repeat(bin_mask[:, :, np.newaxis], 3, axis=2)   # [H, W, 3]
-
-    # Apply mask — background pixels become pure black
+    mask_3c    = np.repeat(bin_mask[:, :, np.newaxis], 3, axis=2)
     cutout_rgb = crop_rgb * mask_3c
 
-    # Save as BGR PNG (OpenCV convention), full resolution
+    ox, oy = crop_origin_xy
+    crop_h, crop_w = crop_rgb.shape[:2]
+    current_bbox_full = detection_bbox_xyxy or (ox, oy, ox + crop_w, oy + crop_h)
+
+    final_bbox_full = current_bbox_full
+    changed = False
+
+    tight = _tight_bbox_from_mask(bin_mask)
+    if tight is not None:
+        tx1, ty1, tx2, ty2 = tight
+        if (tx1, ty1, tx2, ty2) != (0, 0, crop_w, crop_h):
+            cutout_rgb = cutout_rgb[ty1:ty2, tx1:tx2]
+            final_bbox_full = (ox + tx1, oy + ty1, ox + tx2, oy + ty2)
+            changed = True
+
     cv2.imwrite(str(out_path), cv2.cvtColor(cutout_rgb, cv2.COLOR_RGB2BGR))
 
+    # Padding is only a meaningful concept when a detection actually
+    # produced the crop — with no detection, "padded" is inapplicable
+    # rather than false, so keep it None to avoid implying a detection
+    # existed.
+    if detection_bbox_xyxy is None:
+        bbox_padded_field = None
+        pad_px_field = None
+    else:
+        bbox_padded_field = detection_bbox_padded
+        pad_px_field = detection_pad_px if detection_bbox_padded else 0
 
-def _detect_roi_if_enabled(cfg, rgb: np.ndarray) -> Optional[Tuple[int,int,int,int]]:
-    roi_cfg = getattr(cfg.inference, "roi", None)
+    return {
+        "detection_bbox_xyxy": list(current_bbox_full) if detection_bbox_xyxy else None,
+        "detection_bbox_padded": bbox_padded_field,   # ← None | True | False
+        "detection_pad_px": pad_px_field,              # ← None | int
+        "cutout_bbox_xyxy": list(final_bbox_full),
+        "cutout_bbox_changed": changed,
+        "speckles_removed": speckles_removed,
+    }
+
+
+def _detect_roi_if_enabled(roi_cfg, rgb: np.ndarray) -> Optional[Tuple[int,int,int,int]]:
+    
     if not roi_cfg or not getattr(roi_cfg, "enable", False):
         return None
     from ultralytics import YOLO
@@ -167,6 +263,15 @@ def _detect_roi_if_enabled(cfg, rgb: np.ndarray) -> Optional[Tuple[int,int,int,i
     else:
         idx = int(np.argmax(conf))
     x1, y1, x2, y2 = xyxy[idx]
+
+    pad_cfg = getattr(roi_cfg, "detection_padding", {})
+    detection_padding = bool(getattr(pad_cfg, "enabled", False))
+    pad_px = int(getattr(pad_cfg, "pad_px", 0))
+    if detection_padding:
+        x1 = max(0, x1 - pad_px)
+        y1 = max(0, y1 - pad_px)
+        x2 = min(rgb.shape[1], x2 + pad_px)
+        y2 = min(rgb.shape[0], y2 + pad_px)
     return (int(x1), int(y1), int(x2), int(y2))
 
 def _predict_mask(model: torch.nn.Module, x: torch.Tensor, thr: float) -> np.ndarray:
@@ -284,7 +389,8 @@ def run_inference_pipeline(cfg: DictConfig) -> None:
     (run_dir / "masks").mkdir(parents=True, exist_ok=True)
     (run_dir / "overlays").mkdir(parents=True, exist_ok=True)
     (run_dir / "triptych").mkdir(parents=True, exist_ok=True)
-    (run_dir / "cutouts").mkdir(parents=True, exist_ok=True)   # ← NEW
+    (run_dir / "cutouts").mkdir(parents=True, exist_ok=True)
+    (run_dir / "metadata").mkdir(parents=True, exist_ok=True)
 
     # W&B (optional)
     wb_cfg = getattr(getattr(cfg, "inference", None), "logger", {}).get("wandb", {})
@@ -332,7 +438,10 @@ def run_inference_pipeline(cfg: DictConfig) -> None:
     save_triptych = bool(getattr(save_cfg, "triptych", True))
     save_overlay  = bool(getattr(save_cfg, "overlay",  True))
     save_mask     = bool(getattr(save_cfg, "raw_mask", True))
-    save_cutout   = bool(getattr(save_cfg, "cutout",   False))  # ← NEW
+    save_cutout   = bool(getattr(save_cfg, "cutout",   False))
+    save_metadata = bool(getattr(save_cfg, "metadata", False))
+    roi_cfg = getattr(cfg.inference, "roi", None)
+    seg_cfg = getattr(cfg.inference, "seg", None)
 
     # normalization (dataset-wide) if requested
     norm_cfg = getattr(cfg.inference, "normalization", None)
@@ -359,12 +468,17 @@ def run_inference_pipeline(cfg: DictConfig) -> None:
         rgb = _read_rgb(ip)
         H, W = rgb.shape[:2]
 
-        roi = _detect_roi_if_enabled(cfg, rgb)
+        roi = _detect_roi_if_enabled(roi_cfg, rgb)
         if roi is None:
             log.warning(f"[inference] no ROI detected for {ip.name}; segmenting full image.")
             x1, y1, x2, y2 = 0, 0, W, H
         else:
             x1, y1, x2, y2 = roi
+        pad_cfg = getattr(roi_cfg, "detection_padding", {}) if roi_cfg else {}
+        pad_px = int(getattr(pad_cfg, "pad_px", 0))
+        bbox_was_padded = bool(
+            roi is not None and getattr(pad_cfg, "enabled", False) and pad_px > 0
+        )
 
         crop = rgb[y1:y2, x1:x2].copy()
 
@@ -420,13 +534,24 @@ def run_inference_pipeline(cfg: DictConfig) -> None:
             _save_triptych(rgb, mask_u8, overlay, run_dir / "triptych" / f"{stem}_triptych.png",
                            max_side=max_side)
 
-        # ── NEW: vegetation cutout ──────────────────────────────────────
+        # ── vegetation cutout ──────────────────────────────────────
         if save_cutout:
-            _save_vegetation_cutout(
+            cutout_meta = _save_vegetation_cutout(
+                seg_cfg=seg_cfg,
                 crop_rgb=crop,
                 mask_crop=mask_crop,
                 out_path=run_dir / "cutouts" / f"{stem}_cutout.png",
+                crop_origin_xy=(x1, y1),
+                detection_bbox_xyxy=roi,
+                detection_bbox_padded=bbox_was_padded,
+                detection_pad_px=pad_px
             )
+            if save_metadata:
+                _save_metadata_json(
+                    run_dir / "metadata" / f"{stem}.json",
+                    image_name=ip.name,
+                    meta=cutout_meta,
+                )
         # ───────────────────────────────────────────────────────────────
 
         # per-image W&B logging

--- a/src/inference_utils/inference_pipeline.py
+++ b/src/inference_utils/inference_pipeline.py
@@ -43,10 +43,12 @@ def _pad_to_divisor(x: torch.Tensor, divisor: Optional[int]) -> tuple[torch.Tens
     x_pad = F.pad(x, pad, mode="constant", value=0.0)
     return x_pad, (pad[2], pad[3], pad[0], pad[1])  # (top, bottom, left, right)
 
-def _unpad(np_img: np.ndarray, pads: Tuple[int,int,int,int]) -> np.ndarray:
-    t, b, l, r = pads
-    H, W = np_img.shape[:2]
-    return np_img[t:H - b if b > 0 else H, l:W - r if r > 0 else W]
+def _unpad(arr: np.ndarray, pads: Tuple) -> np.ndarray:
+    """Remove padding added by _pad_to_divisor from a 2-D mask array."""
+    _, pad_w, _, pad_h = pads
+    H, W = arr.shape
+    return arr[: H - pad_h if pad_h else H, : W - pad_w if pad_w else W]
+
 
 def _normalize_if_configured(x01: torch.Tensor, norm_cfg) -> torch.Tensor:
     """
@@ -112,6 +114,40 @@ def _save_triptych(rgb: np.ndarray, mask_u8: np.ndarray, overlay: np.ndarray, ou
     panel = np.concatenate([rgb_r, mask_r, overlay_r], axis=1)
     cv2.imwrite(str(out_path), cv2.cvtColor(panel, cv2.COLOR_RGB2BGR))
 
+
+# ─────────────────────────────────────────────────────────────
+# vegetation cutout helper
+# ─────────────────────────────────────────────────────────────
+
+def _save_vegetation_cutout(
+    crop_rgb: np.ndarray,
+    mask_crop: np.ndarray,
+    out_path: Path,
+) -> None:
+    """Save a vegetation segment (cutout) on a pure-black background.
+
+    The cutout is produced by applying the crop-space segmentation mask to
+    the detection crop.  Every pixel outside the mask is set to black
+    (0, 0, 0).  Output is always full-resolution — no downscaling.
+
+    Args:
+        crop_rgb:  Detection crop in RGB uint8 [H, W, 3].
+        mask_crop: Binary mask aligned to ``crop_rgb``, values in {0, 1}
+                   (or {0, 255}).  Pixels where mask > 0 are kept; all
+                   others become black.
+        out_path:  Destination PNG file path.
+    """
+    # Normalise mask to strict binary {0, 1}
+    bin_mask = (mask_crop > 0).astype(np.uint8)                   # [H, W]
+    mask_3c  = np.repeat(bin_mask[:, :, np.newaxis], 3, axis=2)   # [H, W, 3]
+
+    # Apply mask — background pixels become pure black
+    cutout_rgb = crop_rgb * mask_3c
+
+    # Save as BGR PNG (OpenCV convention), full resolution
+    cv2.imwrite(str(out_path), cv2.cvtColor(cutout_rgb, cv2.COLOR_RGB2BGR))
+
+
 def _detect_roi_if_enabled(cfg, rgb: np.ndarray) -> Optional[Tuple[int,int,int,int]]:
     roi_cfg = getattr(cfg.inference, "roi", None)
     if not roi_cfg or not getattr(roi_cfg, "enable", False):
@@ -150,109 +186,82 @@ def _hann2d(h, w):
     return w2d.astype(np.float32)
 
 def _gaussian2d(h, w, sigma_rel=0.3):
-    # sigma as a fraction of tile size (rough, but works well)
-    cy, cx = (h - 1) / 2.0, (w - 1) / 2.0
-    yy, xx = np.mgrid[0:h, 0:w]
-    dy2 = (yy - cy) ** 2
-    dx2 = (xx - cx) ** 2
-    sigma_y = max(1.0, sigma_rel * h)
-    sigma_x = max(1.0, sigma_rel * w)
-    w2d = np.exp(-0.5 * (dy2 / (sigma_y ** 2) + dx2 / (sigma_x ** 2)))
-    w2d = w2d / (w2d.max() + 1e-8)
-    return w2d.astype(np.float32)
+    cy, cx = h / 2.0, w / 2.0
+    sigma_y = sigma_rel * h
+    sigma_x = sigma_rel * w
+    ys = np.arange(h)
+    xs = np.arange(w)
+    yy, xx = np.meshgrid(ys, xs, indexing="ij")
+    g = np.exp(-0.5 * (((yy - cy) / sigma_y) ** 2 + ((xx - cx) / sigma_x) ** 2))
+    g = g / (g.max() + 1e-8)
+    return g.astype(np.float32)
 
-def _tile_blend_window(h, w, method: str, sigma_rel: float) -> np.ndarray:
-    m = (method or "hann").lower()
-    if m == "hann":
-        return _hann2d(h, w)
-    if m == "gaussian":
-        return _gaussian2d(h, w, sigma_rel=sigma_rel)
-    if m == "uniform":
-        return np.ones((h, w), dtype=np.float32)
-    if m == "max":
-        return np.ones((h, w), dtype=np.float32)
-    return _hann2d(h, w)
 
 def _predict_mask_tiled_rgb(
-    model,
-    rgb: np.ndarray,      # ROI or full image, HxWx3 (uint8/RGB)
-    norm_cfg,
-    tile_size: int,
-    overlap: int,
-    divisor: Optional[int],
-    thr: float,
-    blend_method: str = "hann",    # hann | uniform | gaussian | max
-    blend_on: str = "prob",        # prob | bin
+    model: torch.nn.Module,
+    img_rgb: np.ndarray,
+    norm_cfg=None,
+    tile_size: int = 1024,
+    overlap: int = 128,
+    divisor: Optional[int] = 32,
+    thr: float = 0.5,
+    blend_method: str = "hann",
+    blend_on: str = "prob",
     gaussian_sigma_rel: float = 0.3,
-    use_amp: bool = True,          # mixed precision
+    use_amp: bool = True,
 ) -> np.ndarray:
-    """
-    Slide-window inference with overlap and selectable blending.
-    Returns a binary mask (uint8) of the same HxW as rgb.
-    """
-    H, W = rgb.shape[:2]
-    step = max(1, tile_size - overlap)
+    H, W = img_rgb.shape[:2]
+    step = tile_size - overlap
+    use_max = blend_method.lower() == "max"
 
-    # Accumulators
-    if blend_method.lower() == "max":
-        # keep running max (work on probs or bin depending on blend_on)
+    if use_max:
         fused = np.zeros((H, W), dtype=np.float32)
-        use_max = True
     else:
-        acc = np.zeros((H, W), dtype=np.float32)
+        acc  = np.zeros((H, W), dtype=np.float32)
         wsum = np.zeros((H, W), dtype=np.float32)
-        use_max = False
 
     y = 0
     while y < H:
         x = 0
-        y2 = min(y + tile_size, H)
-        y1 = max(0, y2 - tile_size)
-        th = y2 - y1
-
         while x < W:
-            x2 = min(x + tile_size, W)
-            x1 = max(0, x2 - tile_size)
-            tw = x2 - x1
+            y1c, y2c = y, min(y + tile_size, H)
+            x1c, x2c = x, min(x + tile_size, W)
+            tile = img_rgb[y1c:y2c, x1c:x2c]
+            th, tw = tile.shape[:2]
 
-            tile_rgb = rgb[y1:y2, x1:x2, :]
-            win = _tile_blend_window(th, tw, blend_method, gaussian_sigma_rel)
+            tile_t = _to_tensor01(tile)
+            tile_pad, pads = _pad_to_divisor(tile_t, divisor)
+            tile_norm = _normalize_if_configured(tile_pad, norm_cfg)
 
-            # to tensor [1,3,th,tw]
-            tile_x01 = _to_tensor01(tile_rgb)
-
-            # run model on this tile -> prob map
-            # (reuse your single path but return PROB, not bin)
-            # We'll compute prob here directly to avoid thresholding first:
-            tile_xpad, pads = _pad_to_divisor(tile_x01, divisor)
-            tile_xin = _normalize_if_configured(tile_xpad, norm_cfg)
             with torch.inference_mode():
-                if use_amp and torch.cuda.is_available():
+                if use_amp and DEVICE == "cuda":
                     with torch.amp.autocast(device_type="cuda"):
-                        logits = model(tile_xin.to(DEVICE))
+                        logits = model(tile_norm.to(DEVICE))
                         probs = torch.sigmoid(logits).squeeze(0).squeeze(0).detach().cpu().numpy()
                 else:
-                    logits = model(tile_xin.to(DEVICE))
+                    logits = model(tile_norm.to(DEVICE))
                     probs = torch.sigmoid(logits).squeeze(0).squeeze(0).detach().cpu().numpy()
             if divisor:
-                probs = _unpad(probs, pads) # [th, tw]
+                probs = _unpad(probs, pads)
 
-            # pick quantity to blend (prob or bin)
             tile_q = probs if blend_on.lower() == "prob" else (probs >= thr).astype(np.float32)
 
             if use_max:
-                fused[y1:y2, x1:x2] = np.maximum(fused[y1:y2, x1:x2], tile_q)
+                fused[y1c:y2c, x1c:x2c] = np.maximum(fused[y1c:y2c, x1c:x2c], tile_q)
             else:
-                acc[y1:y2, x1:x2] += tile_q * win
-                wsum[y1:y2, x1:x2] += win
+                if blend_method.lower() == "gaussian":
+                    win = _gaussian2d(th, tw, gaussian_sigma_rel)
+                else:
+                    win = _hann2d(th, tw)
+                win = cv2.resize(win, (tile_q.shape[1], tile_q.shape[0]), interpolation=cv2.INTER_LINEAR)
+                acc[y1c:y2c, x1c:x2c]  += tile_q * win
+                wsum[y1c:y2c, x1c:x2c] += win
 
             x += step
         y += step
 
     out = fused if use_max else (acc / np.clip(wsum, 1e-6, None))
-    # final threshold -> binary
-    out_bin = (out >= thr).astype(np.uint8)
-    return out_bin
+    return (out >= thr).astype(np.uint8)
 
 
 # ------------------------- pipeline -------------------------
@@ -263,7 +272,7 @@ def run_inference_pipeline(cfg: DictConfig) -> None:
       - reads images (cfg.inference.input_dir or paths.test_images_dir/val_images_dir)
       - optional ROI detection (YOLO)
       - segmentation with SMP model from cfg.model
-      - saves: raw masks, overlays, and triptych (RGB | mask | overlay)
+      - saves: raw masks, overlays, triptych (RGB | mask | overlay), and vegetation cutouts
       - stores each run under a timestamped subfolder inside the Hydra run dir
       - optionally logs previews to Weights & Biases
     """
@@ -275,6 +284,7 @@ def run_inference_pipeline(cfg: DictConfig) -> None:
     (run_dir / "masks").mkdir(parents=True, exist_ok=True)
     (run_dir / "overlays").mkdir(parents=True, exist_ok=True)
     (run_dir / "triptych").mkdir(parents=True, exist_ok=True)
+    (run_dir / "cutouts").mkdir(parents=True, exist_ok=True)   # ← NEW
 
     # W&B (optional)
     wb_cfg = getattr(getattr(cfg, "inference", None), "logger", {}).get("wandb", {})
@@ -318,9 +328,11 @@ def run_inference_pipeline(cfg: DictConfig) -> None:
     color    = tuple(int(c) for c in getattr(cfg.inference.overlay, "color", [0, 255, 0]))
     max_side = int(getattr(cfg.inference, "preview_max_side", 1200))
 
-    save_triptych = bool(getattr(getattr(cfg.inference, "save", {}), "triptych", True))
-    save_overlay  = bool(getattr(getattr(cfg.inference, "save", {}), "overlay",  True))
-    save_mask     = bool(getattr(getattr(cfg.inference, "save", {}), "raw_mask", True))
+    save_cfg     = getattr(cfg.inference, "save", {})
+    save_triptych = bool(getattr(save_cfg, "triptych", True))
+    save_overlay  = bool(getattr(save_cfg, "overlay",  True))
+    save_mask     = bool(getattr(save_cfg, "raw_mask", True))
+    save_cutout   = bool(getattr(save_cfg, "cutout",   False))  # ← NEW
 
     # normalization (dataset-wide) if requested
     norm_cfg = getattr(cfg.inference, "normalization", None)
@@ -349,6 +361,7 @@ def run_inference_pipeline(cfg: DictConfig) -> None:
 
         roi = _detect_roi_if_enabled(cfg, rgb)
         if roi is None:
+            log.warning(f"[inference] no ROI detected for {ip.name}; segmenting full image.")
             x1, y1, x2, y2 = 0, 0, W, H
         else:
             x1, y1, x2, y2 = roi
@@ -407,7 +420,16 @@ def run_inference_pipeline(cfg: DictConfig) -> None:
             _save_triptych(rgb, mask_u8, overlay, run_dir / "triptych" / f"{stem}_triptych.png",
                            max_side=max_side)
 
-        # --- per-image W&B logging (after files are saved) ---
+        # ── NEW: vegetation cutout ──────────────────────────────────────
+        if save_cutout:
+            _save_vegetation_cutout(
+                crop_rgb=crop,
+                mask_crop=mask_crop,
+                out_path=run_dir / "cutouts" / f"{stem}_cutout.png",
+            )
+        # ───────────────────────────────────────────────────────────────
+
+        # per-image W&B logging
         if use_wandb:
             try:
                 import wandb
@@ -418,6 +440,10 @@ def run_inference_pipeline(cfg: DictConfig) -> None:
                     to_log["inference/overlay"] = wandb.Image(str(run_dir / "overlays" / f"{stem}_overlay.png"))
                 if save_triptych:
                     to_log["inference/triptych"] = wandb.Image(str(run_dir / "triptych" / f"{stem}_triptych.png"))
+                if save_cutout:                                              # ← NEW
+                    to_log["inference/cutout"] = wandb.Image(               # ← NEW
+                        str(run_dir / "cutouts" / f"{stem}_cutout.png")     # ← NEW
+                    )                                                        # ← NEW
                 if to_log:
                     wandb.log(to_log)
             except Exception as e:

--- a/src/inference_utils/inference_pipeline.py
+++ b/src/inference_utils/inference_pipeline.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import glob, json, logging
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Any, cast
 
 import cv2
 import numpy as np
@@ -145,22 +145,6 @@ def _clean_disconnected_mask(bin_mask: np.ndarray, max_gap_px: float) -> np.ndar
             cleaned[comp_pixels] = 1
     return cleaned
 
-def _clean_speckle_mask(bin_mask: np.ndarray, min_area: int) -> np.ndarray:
-    """Drop isolated small blobs from a binary mask, always keeping the
-    largest connected component. Used to strip stray speckles that can
-    appear far from the plant when segmentation runs on the full frame
-    (i.e. no detection/ROI to constrain it).
-    """
-    num, labels, stats, _ = cv2.connectedComponentsWithStats(bin_mask, connectivity=8)
-    if num <= 2:  # background + at most one foreground component already
-        return bin_mask
-    areas = stats[1:, cv2.CC_STAT_AREA]
-    largest_label = 1 + int(np.argmax(areas))
-    cleaned = np.zeros_like(bin_mask)
-    for label in range(1, num):
-        if label == largest_label or stats[label, cv2.CC_STAT_AREA] >= min_area:
-            cleaned[labels == label] = 1
-    return cleaned
 
 def _tight_bbox_from_mask(mask: np.ndarray) -> Optional[Tuple[int, int, int, int]]:
     """
@@ -240,38 +224,83 @@ def _save_vegetation_cutout(
         "detection_pad_px": pad_px_field,              # ← None | int
         "cutout_bbox_xyxy": list(final_bbox_full),
         "cutout_bbox_changed": changed,
-        "speckles_removed": speckles_removed,
+        "mask_cleaned": speckles_removed,
     }
 
 
-def _detect_roi_if_enabled(roi_cfg, rgb: np.ndarray) -> Optional[Tuple[int,int,int,int]]:
-    
+def _detect_roi_if_enabled(
+    roi_cfg,
+    rgb: np.ndarray,
+    yolo_model: Any = None,
+) -> Optional[Tuple[int,int,int,int]]:
+    """Run YOLO-based ROI detection on a full RGB frame and return one box.
+
+    Returns ``(x1, y1, x2, y2)`` in integer pixel coords, or ``None`` when
+    ROI detection is disabled in config or yields no detections.
+
+    Args:
+        yolo_model: Pre-loaded YOLO instance. When provided the model is not
+            reloaded from disk, which is critical for per-image loop performance.
+    """
+    # Skip entirely when ROI detection is not configured or explicitly disabled.
     if not roi_cfg or not getattr(roi_cfg, "enable", False):
         return None
+
+    # Lazy import — only required when ROI detection is active.
     from ultralytics import YOLO
-    yolo = YOLO(roi_cfg.weights)
-    res = yolo.predict(rgb, verbose=False)
-    boxes = res[0].boxes
-    if boxes is None or boxes.xyxy is None or len(boxes.xyxy) == 0:
+
+    def _to_f32(obj: Any) -> np.ndarray:
+        """Normalise a torch.Tensor or np.ndarray to a float32 ndarray."""
+        if isinstance(obj, np.ndarray):
+            return obj.astype(np.float32, copy=False)
+        return cast(np.ndarray, obj.detach().cpu().numpy()).astype(np.float32, copy=False)
+
+    # Use the pre-loaded model when available; otherwise load from disk.
+    # Loading from disk on every call adds significant latency per image.
+    yolo = yolo_model if yolo_model is not None else YOLO(roi_cfg.weights)
+    # cast keeps Pyright happy; ultralytics returns a list of Results objects.
+    # predict() on a single image always returns exactly one Results item.
+    res = cast(list[Any], yolo.predict(rgb, verbose=False))
+
+    # Move the first result to CPU before accessing its tensors.
+    boxes = getattr(res[0].cpu(), "boxes", None)
+    if boxes is None:
         return None
-    xyxy = boxes.xyxy.cpu().numpy()
-    conf = boxes.conf.cpu().numpy() if boxes.conf is not None else np.ones(len(xyxy))
+
+    xyxy_obj = getattr(boxes, "xyxy", None)
+    if xyxy_obj is None:
+        return None
+
+    xyxy = _to_f32(xyxy_obj)
+    if xyxy.shape[0] == 0:
+        return None
+
+    # Build a confidence vector aligned with xyxy rows;
+    # fall back to uniform 1s when conf is unavailable.
+    conf_obj = getattr(boxes, "conf", None)
+    conf = np.ones((xyxy.shape[0],), dtype=np.float32) if conf_obj is None else _to_f32(conf_obj)
+
+    # Select the single box to use: largest area or highest confidence.
     pick = str(getattr(roi_cfg, "pick", "best"))
     if pick == "largest":
         areas = (xyxy[:, 2] - xyxy[:, 0]) * (xyxy[:, 3] - xyxy[:, 1])
         idx = int(np.argmax(areas))
     else:
         idx = int(np.argmax(conf))
-    x1, y1, x2, y2 = xyxy[idx]
 
+    # .tolist() gives a concrete Python list, avoiding Pyright's
+    # "Never is not iterable" false positive on ndarray row unpacking.
+    x1, y1, x2, y2 = map(float, xyxy[idx].tolist())
+
+    # Optionally expand the box by pad_px on every side, clamped to image bounds.
     pad_cfg = getattr(roi_cfg, "detection_padding", {})
-    detection_padding = bool(getattr(pad_cfg, "enabled", False))
     pad_px = int(getattr(pad_cfg, "pad_px", 0))
-    if detection_padding:
-        x1 = max(0, x1 - pad_px)
-        y1 = max(0, y1 - pad_px)
-        x2 = min(rgb.shape[1], x2 + pad_px)
-        y2 = min(rgb.shape[0], y2 + pad_px)
+    if bool(getattr(pad_cfg, "enabled", False)) and pad_px > 0:
+        x1 = max(0.0, x1 - pad_px)
+        y1 = max(0.0, y1 - pad_px)
+        x2 = min(float(rgb.shape[1]), x2 + pad_px)
+        y2 = min(float(rgb.shape[0]), y2 + pad_px)
+
     return (int(x1), int(y1), int(x2), int(y2))
 
 def _predict_mask(model: torch.nn.Module, x: torch.Tensor, thr: float) -> np.ndarray:
@@ -340,7 +369,7 @@ def _predict_mask_tiled_rgb(
 
             with torch.inference_mode():
                 if use_amp and DEVICE == "cuda":
-                    with torch.amp.autocast(device_type="cuda"):
+                    with torch.autocast(device_type="cuda"):
                         logits = model(tile_norm.to(DEVICE))
                         probs = torch.sigmoid(logits).squeeze(0).squeeze(0).detach().cpu().numpy()
                 else:
@@ -403,7 +432,7 @@ def run_inference_pipeline(cfg: DictConfig) -> None:
                 entity=wb_cfg.get("entity", None),
                 name=wb_cfg.get("run_name", stamp),
                 dir=str(run_dir),
-                config=OmegaConf.to_container(cfg, resolve=True),
+                config=cast(dict[str, Any], OmegaConf.to_container(cfg, resolve=True)),
                 save_code=False,
                 reinit=True,
             )
@@ -443,6 +472,15 @@ def run_inference_pipeline(cfg: DictConfig) -> None:
     roi_cfg = getattr(cfg.inference, "roi", None)
     seg_cfg = getattr(cfg.inference, "seg", None)
 
+
+    # Pre-load YOLO ROI model once — reused for every image in the loop.
+    # Loading the model inside the loop would reload weights from disk each iteration.
+    _roi_yolo = None
+    if roi_cfg and getattr(roi_cfg, "enable", False):
+        from ultralytics import YOLO as _YOLO
+        _roi_yolo = _YOLO(roi_cfg.weights)
+        log.info(f"[inference] ROI model loaded: {roi_cfg.weights}")
+
     # normalization (dataset-wide) if requested
     norm_cfg = getattr(cfg.inference, "normalization", None)
 
@@ -462,13 +500,13 @@ def run_inference_pipeline(cfg: DictConfig) -> None:
     if not imgs:
         log.warning(f"[inference] no images found under: {img_root}")
         return
-
+    
     # main loop
     for ip in imgs:
         rgb = _read_rgb(ip)
         H, W = rgb.shape[:2]
 
-        roi = _detect_roi_if_enabled(roi_cfg, rgb)
+        roi = _detect_roi_if_enabled(roi_cfg, rgb, yolo_model=_roi_yolo)
         if roi is None:
             log.warning(f"[inference] no ROI detected for {ip.name}; segmenting full image.")
             x1, y1, x2, y2 = 0, 0, W, H
@@ -536,6 +574,7 @@ def run_inference_pipeline(cfg: DictConfig) -> None:
 
         # ── vegetation cutout ──────────────────────────────────────
         if save_cutout:
+            assert seg_cfg is not None, "seg config must be provided to save cutouts"
             cutout_meta = _save_vegetation_cutout(
                 seg_cfg=seg_cfg,
                 crop_rgb=crop,


### PR DESCRIPTION
updates the inference pipeline with support for vegetation cutouts, improved mask post-processing, and  options for ROI detection and segmentation.

Main changes include:

**Vegetation cutouts**

* Adds support for saving vegetation cutouts from inference runs.
* Saves related metadata, including detection bounding boxes and cutout bounding boxes.
* Supports both LTS and standard pipeline inference workflows.

**ROI detection**

* Adds configurable padding around detected ROIs before segmentation.
* Helps ensure the full plant is included in the segmentation area.
* Padding can be enabled, disabled, and adjusted in the config.

**Mask post-processing**

* Adds utilities for cleaning segmentation masks:

  * `clean_disconnected_mask`: removes disconnected mask regions.
  * `clean_speckle_mask`: removes small speckles.
* Mask cleaning behavior is configurable.

**Tiled segmentation**

* Improves tiled segmentation blending.
* Fixes the Gaussian blending window.
* Improves handling of tile overlap and accumulated predictions.

**Other updates**

* Updates comments and documentation for the new cutout and metadata outputs.
* Improves logging when ROIs are missing.

Overall, these changes make the inference pipeline more robust and configurable, especially for plant segmentation workflows that need accurate cutouts and metadata tracking.
